### PR TITLE
Add a cell argument to the stress function.

### DIFF
--- a/include/fiddle/mechanics/force_contribution.h
+++ b/include/fiddle/mechanics/force_contribution.h
@@ -170,12 +170,15 @@ namespace fdl
     }
 
     virtual void
-    compute_stress(const double                            time,
-                   const MechanicsValues<dim, spacedim> &  me_values,
-                   ArrayView<Tensor<2, spacedim, Number>> &stresses) const
+    compute_stress(
+      const double                          time,
+      const MechanicsValues<dim, spacedim> &me_values,
+      const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+      ArrayView<Tensor<2, spacedim, Number>> &stresses) const
     {
       (void)time;
       (void)me_values;
+      (void)cell;
       (void)stresses;
       Assert(false, ExcFDLInternalError());
     }

--- a/source/mechanics/mechanics_utilities.cc
+++ b/source/mechanics/mechanics_utilities.cc
@@ -114,7 +114,7 @@ namespace fdl
                               Tensor<2, spacedim, double>());
                     auto view =
                       make_array_view(one_stress.begin(), one_stress.end());
-                    fc->compute_stress(time, me_values, view);
+                    fc->compute_stress(time, me_values, cell, view);
                     for (unsigned int qp_n = 0; qp_n < n_quadrature_points;
                          ++qp_n)
                       accumulated_stresses[qp_n] += one_stress[qp_n];

--- a/tests/interaction/ifed_ex4.cc
+++ b/tests/interaction/ifed_ex4.cc
@@ -69,6 +69,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     const std::vector<Tensor<2, spacedim>> &FF = me_values.get_FF();
@@ -119,6 +121,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     const std::vector<double> &             det_FF   = me_values.get_det_FF();

--- a/tests/interaction/ifed_ex4_simplex.cc
+++ b/tests/interaction/ifed_ex4_simplex.cc
@@ -70,6 +70,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     const std::vector<Tensor<2, spacedim>> &FF = me_values.get_FF();
@@ -120,6 +122,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     const std::vector<double> &             det_FF   = me_values.get_det_FF();

--- a/tests/mechanics/pk1_volumetric_01.cc
+++ b/tests/mechanics/pk1_volumetric_01.cc
@@ -60,6 +60,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     Assert(spacedim == 2, fdl::ExcFDLNotImplemented());

--- a/tests/mechanics/pk1_volumetric_02.cc
+++ b/tests/mechanics/pk1_volumetric_02.cc
@@ -120,6 +120,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     Assert(spacedim == 2, fdl::ExcFDLNotImplemented());

--- a/tests/mechanics/pk1_volumetric_03.cc
+++ b/tests/mechanics/pk1_volumetric_03.cc
@@ -119,6 +119,8 @@ public:
   compute_stress(
     const double /*time*/,
     const fdl::MechanicsValues<dim, spacedim> &me_values,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+    & /*cell*/,
     ArrayView<Tensor<2, spacedim, double>> &   stresses) const override
   {
     Assert(spacedim == 2, fdl::ExcFDLNotImplemented());


### PR DESCRIPTION
Originally, I planned on not doing this since we might want to evaluate these on surfaces. I think I'll leave that unsupported for now to make this function more like the others.