### PR TITLE
Make MechanicsValues<dim>::reint() take a cell iterator.

### DIFF
--- a/source/mechanics/mechanics_utilities.cc
+++ b/source/mechanics/mechanics_utilities.cc
@@ -98,7 +98,7 @@ namespace fdl
               {
                 cell->get_dof_indices(cell_dofs);
                 fe_values.reinit(cell);
-                me_values.reinit();
+                me_values.reinit(cell);
                 std::fill(accumulated_stresses.begin(),
                           accumulated_stresses.end(),
                           Tensor<2, spacedim, double>());
@@ -216,7 +216,7 @@ namespace fdl
               {
                 cell->get_dof_indices(cell_dofs);
                 fe_values.reinit(cell);
-                me_values.reinit();
+                me_values.reinit(cell);
                 std::fill(accumulated_forces.begin(),
                           accumulated_forces.end(),
                           Tensor<1, spacedim, double>());
@@ -337,7 +337,7 @@ namespace fdl
                 {
                   cell->get_dof_indices(cell_dofs);
                   fe_values.reinit(cell, face_n);
-                  me_values.reinit();
+                  me_values.reinit(cell);
                   std::fill(accumulated_forces.begin(),
                             accumulated_forces.end(),
                             Tensor<1, spacedim, double>());

--- a/tests/mechanics/me_values_01.cc
+++ b/tests/mechanics/me_values_01.cc
@@ -67,7 +67,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
         fe_values.reinit(cell);
-        mechanics_values.reinit();
+        mechanics_values.reinit(cell);
 
         out << "J:\n";
         for (const double &J : mechanics_values.get_det_FF())

--- a/tests/mechanics/me_values_02.cc
+++ b/tests/mechanics/me_values_02.cc
@@ -69,7 +69,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
         fe_values.reinit(cell);
-        mechanics_values.reinit();
+        mechanics_values.reinit(cell);
 
         out << "J:\n";
         for (const double &J : mechanics_values.get_det_FF())


### PR DESCRIPTION
This makes getting DoF values more efficient since we can do a boring copy without using a deal.II function that creates multiple temporary arrays.