### PR TITLE
Run the new version of clang-format

### DIFF
--- a/include/fiddle/mechanics/force_contribution.h
+++ b/include/fiddle/mechanics/force_contribution.h
@@ -129,7 +129,7 @@ namespace fdl
     virtual void
     compute_force(
       const double                            time,
-      const MechanicsValues<dim, spacedim> &  m_values,
+      const MechanicsValues<dim, spacedim>   &m_values,
       ArrayView<Tensor<1, spacedim, Number>> &forces) const // = 0 TODO fix this
     {
       // It shouldn't be possible to get here but since compute_surface_force

--- a/include/fiddle/mechanics/force_contribution_lib.h
+++ b/include/fiddle/mechanics/force_contribution_lib.h
@@ -35,20 +35,20 @@ namespace fdl
      * Applies the force on every cell.
      */
     SpringForce(
-      const Quadrature<dim> &                           quad,
+      const Quadrature<dim>                            &quad,
       const double                                      spring_constant,
-      const DoFHandler<dim, spacedim> &                 dof_handler,
+      const DoFHandler<dim, spacedim>                  &dof_handler,
       const LinearAlgebra::distributed::Vector<double> &reference_position);
 
     /**
      * Same, but for an initial position set up by a Function instead of a
      * specified vector.
      */
-    SpringForce(const Quadrature<dim> &          quad,
+    SpringForce(const Quadrature<dim>           &quad,
                 const double                     spring_constant,
                 const DoFHandler<dim, spacedim> &dof_handler,
-                const Mapping<dim, spacedim> &   mapping,
-                const Function<spacedim> &       reference_function);
+                const Mapping<dim, spacedim>    &mapping,
+                const Function<spacedim>        &reference_function);
 
     /**
      * Constructor. Same idea, but only applies the force on cells with the
@@ -58,22 +58,22 @@ namespace fdl
      * any cell.
      */
     SpringForce(
-      const Quadrature<dim> &                           quad,
+      const Quadrature<dim>                            &quad,
       const double                                      spring_constant,
-      const DoFHandler<dim, spacedim> &                 dof_handler,
-      const std::vector<types::material_id> &           material_ids,
+      const DoFHandler<dim, spacedim>                  &dof_handler,
+      const std::vector<types::material_id>            &material_ids,
       const LinearAlgebra::distributed::Vector<double> &reference_position);
 
     /**
      * Same, but for an initial position set up by a Function instead of a
      * specified vector.
      */
-    SpringForce(const Quadrature<dim> &                quad,
+    SpringForce(const Quadrature<dim>                 &quad,
                 const double                           spring_constant,
-                const DoFHandler<dim, spacedim> &      dof_handler,
-                const Mapping<dim, spacedim> &         mapping,
+                const DoFHandler<dim, spacedim>       &dof_handler,
+                const Mapping<dim, spacedim>          &mapping,
                 const std::vector<types::material_id> &material_ids,
-                const Function<spacedim> &             reference_position);
+                const Function<spacedim>              &reference_position);
 
     /**
      * Set the reference position to a new value.

--- a/include/fiddle/mechanics/mechanics_utilities.h
+++ b/include/fiddle/mechanics/mechanics_utilities.h
@@ -22,13 +22,13 @@ namespace fdl
   template <int dim, int spacedim = dim>
   void
   compute_volumetric_pk1_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &stress_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs);
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs);
 
   /**
    * Compute the contribution of volumetric forces and add them to the given
@@ -37,13 +37,13 @@ namespace fdl
   template <int dim, int spacedim = dim>
   void
   compute_volumetric_force_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &force_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs);
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs);
 
   /**
    * Compute the contribution of boundary forces and add them to the given load
@@ -52,13 +52,13 @@ namespace fdl
   template <int dim, int spacedim = dim>
   void
   compute_boundary_force_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &force_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs);
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs);
 
   /**
    * Combined function that calls all of the previous functions.
@@ -66,13 +66,13 @@ namespace fdl
   template <int dim, int spacedim = dim>
   void
   compute_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &force_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs);
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs);
 } // namespace fdl
 
 #endif

--- a/source/mechanics/force_contribution_lib.cc
+++ b/source/mechanics/force_contribution_lib.cc
@@ -19,8 +19,8 @@ namespace fdl
     template <int dim, int spacedim>
     LinearAlgebra::distributed::Vector<double>
     do_interpolation(const DoFHandler<dim, spacedim> &dof_handler,
-                     const Mapping<dim, spacedim> &   mapping,
-                     const Function<spacedim> &       reference_position)
+                     const Mapping<dim, spacedim>    &mapping,
+                     const Function<spacedim>        &reference_position)
     {
       IndexSet locally_relevant_dofs;
       DoFTools::extract_locally_relevant_dofs(dof_handler,
@@ -57,9 +57,9 @@ namespace fdl
 
   template <int dim, int spacedim, typename Number>
   SpringForce<dim, spacedim, Number>::SpringForce(
-    const Quadrature<dim> &                           quad,
+    const Quadrature<dim>                            &quad,
     const double                                      spring_constant,
-    const DoFHandler<dim, spacedim> &                 dof_handler,
+    const DoFHandler<dim, spacedim>                  &dof_handler,
     const LinearAlgebra::distributed::Vector<double> &reference_position)
     : ForceContribution<dim, spacedim, double>(quad)
     , spring_constant(spring_constant)
@@ -71,11 +71,11 @@ namespace fdl
 
   template <int dim, int spacedim, typename Number>
   SpringForce<dim, spacedim, Number>::SpringForce(
-    const Quadrature<dim> &          quad,
+    const Quadrature<dim>           &quad,
     const double                     spring_constant,
     const DoFHandler<dim, spacedim> &dof_handler,
-    const Mapping<dim, spacedim> &   mapping,
-    const Function<spacedim> &       reference_position)
+    const Mapping<dim, spacedim>    &mapping,
+    const Function<spacedim>        &reference_position)
     : ForceContribution<dim, spacedim, double>(quad)
     , spring_constant(spring_constant)
     , dof_handler(&dof_handler)
@@ -87,10 +87,10 @@ namespace fdl
 
   template <int dim, int spacedim, typename Number>
   SpringForce<dim, spacedim, Number>::SpringForce(
-    const Quadrature<dim> &                           quad,
+    const Quadrature<dim>                            &quad,
     const double                                      spring_constant,
-    const DoFHandler<dim, spacedim> &                 dof_handler,
-    const std::vector<types::material_id> &           material_ids,
+    const DoFHandler<dim, spacedim>                  &dof_handler,
+    const std::vector<types::material_id>            &material_ids,
     const LinearAlgebra::distributed::Vector<double> &reference_position)
     : ForceContribution<dim, spacedim, double>(quad)
     , material_ids(setup_material_ids(material_ids))
@@ -103,12 +103,12 @@ namespace fdl
 
   template <int dim, int spacedim, typename Number>
   SpringForce<dim, spacedim, Number>::SpringForce(
-    const Quadrature<dim> &                quad,
+    const Quadrature<dim>                 &quad,
     const double                           spring_constant,
-    const DoFHandler<dim, spacedim> &      dof_handler,
-    const Mapping<dim, spacedim> &         mapping,
+    const DoFHandler<dim, spacedim>       &dof_handler,
+    const Mapping<dim, spacedim>          &mapping,
     const std::vector<types::material_id> &material_ids,
-    const Function<spacedim> &             reference_position)
+    const Function<spacedim>              &reference_position)
     : ForceContribution<dim, spacedim, double>(quad)
     , material_ids(setup_material_ids(material_ids))
     , spring_constant(spring_constant)
@@ -171,7 +171,7 @@ namespace fdl
   void
   SpringForce<dim, spacedim, Number>::compute_volume_force(
     const double /*time*/,
-    const MechanicsValues<dim, spacedim> &                             m_values,
+    const MechanicsValues<dim, spacedim>                              &m_values,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     ArrayView<Tensor<1, spacedim, Number>> &forces) const
   {

--- a/source/mechanics/mechanics_utilities.cc
+++ b/source/mechanics/mechanics_utilities.cc
@@ -20,13 +20,13 @@ namespace fdl
   template <int dim, int spacedim>
   void
   compute_volumetric_pk1_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &stress_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs)
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs)
   {
     for (const auto *p : stress_contributions)
       {
@@ -49,13 +49,13 @@ namespace fdl
   void
   compute_volumetric_force_load_vector(
     const DoFHandler<dim, spacedim> &dof_handler,
-    const Mapping<dim, spacedim> &   mapping,
+    const Mapping<dim, spacedim>    &mapping,
     const std::vector<ForceContribution<dim, spacedim> *>
-      &          volume_force_contributions,
+                &volume_force_contributions,
     const double time,
     const LinearAlgebra::distributed::Vector<double> &current_position,
     const LinearAlgebra::distributed::Vector<double> &current_velocity,
-    LinearAlgebra::distributed::Vector<double> &      force_rhs)
+    LinearAlgebra::distributed::Vector<double>       &force_rhs)
   {
     for (const auto *p : volume_force_contributions)
       {
@@ -79,13 +79,13 @@ namespace fdl
   void
   compute_boundary_force_load_vector(
     const DoFHandler<dim, spacedim> &dof_handler,
-    const Mapping<dim, spacedim> &   mapping,
+    const Mapping<dim, spacedim>    &mapping,
     const std::vector<ForceContribution<dim, spacedim> *>
-      &          boundary_force_contributions,
+                &boundary_force_contributions,
     const double time,
     const LinearAlgebra::distributed::Vector<double> &current_position,
     const LinearAlgebra::distributed::Vector<double> &current_velocity,
-    LinearAlgebra::distributed::Vector<double> &      force_rhs)
+    LinearAlgebra::distributed::Vector<double>       &force_rhs)
   {
     Assert(dim == spacedim, ExcNotImplemented());
 
@@ -200,13 +200,13 @@ namespace fdl
   template <int dim, int spacedim>
   void
   compute_load_vector(
-    const DoFHandler<dim, spacedim> &                      dof_handler,
-    const Mapping<dim, spacedim> &                         mapping,
+    const DoFHandler<dim, spacedim>                       &dof_handler,
+    const Mapping<dim, spacedim>                          &mapping,
     const std::vector<ForceContribution<dim, spacedim> *> &force_contributions,
     const double                                           time,
-    const LinearAlgebra::distributed::Vector<double> &     current_position,
-    const LinearAlgebra::distributed::Vector<double> &     current_velocity,
-    LinearAlgebra::distributed::Vector<double> &           force_rhs)
+    const LinearAlgebra::distributed::Vector<double>      &current_position,
+    const LinearAlgebra::distributed::Vector<double>      &current_velocity,
+    LinearAlgebra::distributed::Vector<double>            &force_rhs)
   {
     Assert(dim == spacedim, ExcNotImplemented());
 

--- a/source/mechanics/part.cc
+++ b/source/mechanics/part.cc
@@ -15,11 +15,11 @@ namespace fdl
     // matrix_free doesn't work with codim != 0 so we need a helper function
     template <int dim>
     void
-    reinit_matrix_free(const Mapping<dim> &             mapping,
-                       const DoFHandler<dim> &          dof_handler,
+    reinit_matrix_free(const Mapping<dim>              &mapping,
+                       const DoFHandler<dim>           &dof_handler,
                        const AffineConstraints<double> &constraints,
-                       const Quadrature<dim> &          quadrature,
-                       MatrixFree<dim, double> &        matrix_free)
+                       const Quadrature<dim>           &quadrature,
+                       MatrixFree<dim, double>         &matrix_free)
     {
       matrix_free.reinit(mapping, dof_handler, constraints, quadrature);
     }


### PR DESCRIPTION
clang-format 13 finally lets us align `&`s \o/