### PR TITLE
Fix the default value of UpdateFlags.

### DIFF
--- a/include/fiddle/mechanics/force_contribution.h
+++ b/include/fiddle/mechanics/force_contribution.h
@@ -67,10 +67,19 @@ namespace fdl
 
     /**
      * Get the update flags this force contribution requires for FEValues
-     * objects.
+     * objects. Defaults to using compute_flag_dependencies() to return whatever
+     * UpdateFlags are required by the provided MechanicsUpdateFlags.
+     *
+     * This function usually does not need to be changed by inheriting classes,
+     * but if you do, then remember to either call the base class function, use
+     * compute_flag_dependencies(), or manually resolve the flag dependencies
+     * yourself.
      */
     virtual UpdateFlags
-    get_update_flags() const = 0;
+    get_update_flags() const
+    {
+      return compute_flag_dependencies(get_mechanics_update_flags());
+    }
 
     virtual bool
     is_stress() const

--- a/include/fiddle/mechanics/force_contribution_lib.h
+++ b/include/fiddle/mechanics/force_contribution_lib.h
@@ -241,13 +241,6 @@ namespace fdl
     virtual MechanicsUpdateFlags
     get_mechanics_update_flags() const override;
 
-    /**
-     * Get the update flags this force contribution requires for FEValues
-     * objects.
-     */
-    virtual UpdateFlags
-    get_update_flags() const override;
-
     virtual bool
     is_volume_force() const override;
 

--- a/source/mechanics/force_contribution_lib.cc
+++ b/source/mechanics/force_contribution_lib.cc
@@ -366,13 +366,6 @@ namespace fdl
   }
 
   template <int dim, int spacedim, typename Number>
-  UpdateFlags
-  DampingForce<dim, spacedim, Number>::get_update_flags() const
-  {
-    return UpdateFlags::update_default;
-  }
-
-  template <int dim, int spacedim, typename Number>
   bool
   DampingForce<dim, spacedim, Number>::is_volume_force() const
   {


### PR DESCRIPTION
The most common use case is that we compute stresses etc. with invariants or other known functions - its rare that we actually need to specify `UpdateFlags` values here.