### PR TITLE
Add support for meter meshes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ SET(FIDDLE_SRC
   source/mechanics/part_vectors.cc
 
   source/postprocess/point_values.cc
+  source/postprocess/meter_mesh.cc
 
   source/transfer/overlap_partitioning_tools.cc
   source/transfer/scatter.cc

--- a/include/fiddle/postprocess/meter_mesh.h
+++ b/include/fiddle/postprocess/meter_mesh.h
@@ -49,7 +49,9 @@ namespace fdl
               const DoFHandler<dim, spacedim>    &position_dof_handler,
               const std::vector<Point<spacedim>> &convex_hull,
               tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
-              const int                                         level_number);
+              const int                                         level_number,
+              const LinearAlgebra::distributed::Vector<double> &position,
+              const LinearAlgebra::distributed::Vector<double> &velocity);
 
     /**
      * Reinitialize the meter mesh to have its coordinates specified by @p
@@ -91,14 +93,14 @@ namespace fdl
 
   protected:
     /**
-     * Original DoFHandler.
-     */
-    SmartPointer<const DoFHandler<dim, spacedim>> position_dof_handler;
-
-    /**
      * Original Mapping.
      */
     SmartPointer<const Mapping<dim, spacedim>> mapping;
+
+    /**
+     * Original DoFHandler.
+     */
+    SmartPointer<const DoFHandler<dim, spacedim>> position_dof_handler;
 
     /**
      * Cartesian-grid data.

--- a/include/fiddle/postprocess/meter_mesh.h
+++ b/include/fiddle/postprocess/meter_mesh.h
@@ -1,0 +1,153 @@
+#ifndef included_fiddle_postprocess_meter_mesh_h
+#define included_fiddle_postprocess_meter_mesh_h
+
+#include <fiddle/base/config.h>
+
+#include <fiddle/interaction/nodal_interaction.h>
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/mapping.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <fiddle/postprocess/point_values.h>
+
+#include <vector>
+
+namespace fdl
+{
+  using namespace dealii;
+
+  /**
+   * Class for integrating Cartesian-grid values on codimension one surfaces
+   * (colloquially a 'meter mesh').
+   */
+  template <int dim, int spacedim = dim>
+  class MeterMesh
+  {
+  public:
+    /**
+     * Constructor.
+     *
+     * @param[in] mapping Mapping defined in reference coordinates (e.g.,, the
+     * mapping returned by Part::get_mapping())
+     *
+     * @param[in] position_dof_handler DoFHandler describing the position and
+     * velocity finite element spaces.
+     *
+     * @param[in] convex_hull Points, in reference coordinates, describing the
+     * boundary of the meter mesh. These points typically outline a disk and
+     * typically come from a node set defined on the Triangulation associated
+     * with @p dof_handler.
+     */
+    MeterMesh(const Mapping<dim, spacedim>       &mapping,
+              const DoFHandler<dim, spacedim>    &position_dof_handler,
+              const std::vector<Point<spacedim>> &convex_hull,
+              tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
+              const int                                         level_number);
+
+    /**
+     * Reinitialize the meter mesh to have its coordinates specified by @p
+     * position and velocity by @p velocity.
+     */
+    void
+    reinit(const LinearAlgebra::distributed::Vector<double> &position,
+           const LinearAlgebra::distributed::Vector<double> &velocity);
+
+    /**
+     * Return the mean meter velocity, defined as the average value of the
+     * volumetric finite element velocity evaluated on the convex hull.
+     */
+    Tensor<1, spacedim>
+    mean_meter_velocity() const;
+
+    /**
+     * Compute the mean flux of some vector-valued quantity through the meter
+     * mesh. If @p data_idx is the velocity field then typically one should
+     * subtract the mean meter velocity from this value to attain a physically
+     * relevant flux value.
+     *
+     * @param[in] data_idx Some data index corresponding to data on the
+     * Cartesian grid. This class will copy the data into a scratch index and
+     * update ghost data.
+     */
+    Tensor<1, spacedim>
+    mean_flux(const int data_idx, const std::string &kernel_name);
+
+    /**
+     * Compute the mean value of some scalar-valued quantity.
+     *
+     * @param[in] data_idx Some data index corresponding to data on the
+     * Cartesian grid. This class will copy the data into a scratch index and
+     * update ghost data.
+     */
+    double
+    mean_value(const int data_idx, const std::string &kernel_name);
+
+  protected:
+    /**
+     * Original DoFHandler.
+     */
+    SmartPointer<const DoFHandler<dim, spacedim>> position_dof_handler;
+
+    /**
+     * Original Mapping.
+     */
+    SmartPointer<const Mapping<dim, spacedim>> mapping;
+
+    /**
+     * Cartesian-grid data.
+     * @{
+     */
+    tbox::Pointer<hier::BasePatchHierachy<spacedim>> patch_hierarchy;
+
+    std::shared_ptr<IBTK::SAMRAIDataCache> eulerian_data_cache;
+
+    int level_number;
+    /**
+     * @}
+     */
+
+    /**
+     * PointValues object for computing the mesh's position and velocity.
+     */
+    std::unique_ptr<PointValues<spacedim, dim, spacedim>> point_values;
+
+    /**
+     * Meter Triangulation.
+     */
+    parallel::shared::Triangulation<dim - 1, spacedim> meter_tria;
+
+    /**
+     * Scalar FiniteElement used on meter_tria;
+     */
+    std::unique_ptr<FiniteElement<dim - 1, spacedim>> scalar_fe;
+
+    /**
+     * Vector FiniteElement used on meter_tria;
+     */
+    std::unique_ptr<FiniteElement<dim - 1, spacedim>> vector_fe;
+
+    /**
+     * DoFHandler for scalar quantities defined on meter_tria.
+     */
+    DoFHandler<dim - 1, spacedim> scalar_dof_handler;
+
+    /**
+     * DoFHandler for vector-valued quantities defined on meter_tria.
+     */
+    DoFHandler<dim - 1, spacedim> vector_dof_handler;
+
+    /**
+     * Interaction object.
+     */
+    NodalInteraction<dim - 1, spacedim> nodal_interaction;
+  };
+} // namespace fdl
+
+#endif

--- a/source/postprocess/meter_mesh.cc
+++ b/source/postprocess/meter_mesh.cc
@@ -1,0 +1,73 @@
+#include <fiddle/postprocess/meter_mesh.h>
+
+namespace fdl
+{
+  namespace internal
+  {
+    namespace
+    {
+      void
+      setup_meter_tria(const std::vector<Point<2>> &          hull,
+                       parallel::shared::Triangulation<1, 2> &tria,
+                       const double /*target_element_area*/)
+      {
+        // Somewhat simpler case: just connect the dots.
+        Assert(hull.size() > 1, ExcFDLInternalError());
+        std::vector<CellData<1>> cell_data;
+
+        for (unsigned int vertex_n = 0; vertex_n < hull.size() - 1; ++vertex_n)
+          {
+            cell_data.emplace_back();
+            cell_data.back().vertices[0] = vertex_n;
+            cell_data.back().vertices[1] = vertex_n + 1;
+          }
+
+        tria.make_triangulation(hull, cell_data, SubCellData());
+      }
+
+      void
+      setup_meter_tria(const std::vector<Point<3>> &          convex_hull,
+                       parallel::shared::Triangulation<1, 2> &tria,
+                       const double target_element_area)
+      {
+        Assert(hull.size() > 2, ExcFDLInternalError());
+
+        Triangle::AdditionalData additional_data;
+        additional_data.target_element_area = target_element_area;
+        triangulate_convex(hull_vertices, tria, additional_data);
+      }
+    } // namespace
+  }   // namespace internal
+
+  template <int dim, int spacedim>
+  MeterMesh::MeterMesh(
+    const Mapping<dim, spacedim> &                    mapping,
+    const DoFHandler<dim, spacedim> &                 position_dof_handler,
+    const std::vector<Point<spacedim>> &              convex_hull,
+    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
+    const int                                         level_number,
+    const LinearAlgebra::distributed::Vector<double> &position,
+    const LinearAlgebra::distributed::Vector<double> &velocity)
+    : mapping(&mapping)
+    , position_dof_handler(&position_dof_handler)
+    , patch_hierarchy(patch_hierarchy)
+    , level_number(level_number)
+    , point_values(std::make_unique<PointValues<spacedim, dim, spacedim>>(
+        mapping,
+        position_dof_handler,
+        convex_hull))
+    , meter_tria(tbox::SAMRAI_MPI::getCommunicator(),
+                 Triangulation<dim, spacedim>::MeshSmoothing::none,
+                 true)
+  {
+    const std::vector<Tensor<1, spacedim>> position_values =
+      point_values->evaluate(position);
+    const std::vector<Point<spacedim>> positions(position_values.begin(),
+                                                 position_values.end());
+
+
+    // TODO: determine dx here
+    
+    setup_meter_tria(positions, meter_tria, target_element_area);
+  }
+} // namespace fdl

--- a/source/postprocess/meter_mesh.cc
+++ b/source/postprocess/meter_mesh.cc
@@ -1,4 +1,22 @@
+#include <fiddle/base/exceptions.h>
+
+#include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/surface_tria.h>
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <CartesianPatchGeometry.h>
 #include <fiddle/postprocess/meter_mesh.h>
+
+#include <cmath>
+#include <limits>
 
 namespace fdl
 {
@@ -6,12 +24,15 @@ namespace fdl
   {
     namespace
     {
+      // avoid "defined but not used" warnings by using NDIM
+#if NDIM == 2
       void
       setup_meter_tria(const std::vector<Point<2>> &          hull,
                        parallel::shared::Triangulation<1, 2> &tria,
                        const double /*target_element_area*/)
       {
-        // Somewhat simpler case: just connect the dots.
+        // TODO: make sure that we add enough extra elements to each line
+        // segment to meet the target_element_area requirement.
         Assert(hull.size() > 1, ExcFDLInternalError());
         std::vector<CellData<1>> cell_data;
 
@@ -22,34 +43,34 @@ namespace fdl
             cell_data.back().vertices[1] = vertex_n + 1;
           }
 
-        tria.make_triangulation(hull, cell_data, SubCellData());
+        tria.create_triangulation(hull, cell_data, SubCellData());
       }
-
+#else
       void
       setup_meter_tria(const std::vector<Point<3>> &          convex_hull,
-                       parallel::shared::Triangulation<1, 2> &tria,
+                       parallel::shared::Triangulation<2, 3> &tria,
                        const double target_element_area)
       {
-        Assert(hull.size() > 2, ExcFDLInternalError());
+        Assert(convex_hull.size() > 2, ExcFDLInternalError());
 
         Triangle::AdditionalData additional_data;
         additional_data.target_element_area = target_element_area;
-        triangulate_convex(hull_vertices, tria, additional_data);
+        // TODO - use the normal vector returned by setup_meter_tria() somewhere
+        setup_planar_meter_mesh(convex_hull, tria, additional_data);
       }
+#endif
     } // namespace
   }   // namespace internal
 
   template <int dim, int spacedim>
-  MeterMesh::MeterMesh(
+  MeterMesh<dim, spacedim>::MeterMesh(
     const Mapping<dim, spacedim> &                    mapping,
     const DoFHandler<dim, spacedim> &                 position_dof_handler,
     const std::vector<Point<spacedim>> &              convex_hull,
     tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
     const int                                         level_number,
-    const LinearAlgebra::distributed::Vector<double> &position,
-    const LinearAlgebra::distributed::Vector<double> &velocity)
+    const LinearAlgebra::distributed::Vector<double> &position)
     : mapping(&mapping)
-    , position_dof_handler(&position_dof_handler)
     , patch_hierarchy(patch_hierarchy)
     , level_number(level_number)
     , point_values(std::make_unique<PointValues<spacedim, dim, spacedim>>(
@@ -57,17 +78,130 @@ namespace fdl
         position_dof_handler,
         convex_hull))
     , meter_tria(tbox::SAMRAI_MPI::getCommunicator(),
-                 Triangulation<dim, spacedim>::MeshSmoothing::none,
+                 Triangulation<dim - 1, spacedim>::MeshSmoothing::none,
                  true)
+    , scalar_fe(std::make_unique<FE_SimplexP<dim - 1, spacedim>>(1))
+    , vector_fe(
+        std::make_unique<FESystem<dim - 1, spacedim>>(*scalar_fe, spacedim))
   {
+    // TODO: assert congruity between position_dof_handler.get_communicator()
+    // and SAMRAI_MPI::getCommunicator()
+    reinit(position);
+  }
+
+  template <int dim, int spacedim>
+  void
+  MeterMesh<dim, spacedim>::reinit(
+    const LinearAlgebra::distributed::Vector<double> &position)
+  {
+    // Reset the meter mesh according to the new position values:
     const std::vector<Tensor<1, spacedim>> position_values =
       point_values->evaluate(position);
     const std::vector<Point<spacedim>> positions(position_values.begin(),
                                                  position_values.end());
 
+    double dx_0 = std::numeric_limits<double>::max();
+    tbox::Pointer<hier::PatchLevel<spacedim>> level =
+      patch_hierarchy->getPatchLevel(level_number);
+    for (typename hier::PatchLevel<spacedim>::Iterator p(level); p; p++)
+      {
+        tbox::Pointer<hier::Patch<spacedim>> patch = level->getPatch(p());
+        const tbox::Pointer<geom::CartesianPatchGeometry<spacedim>> pgeom =
+          patch->getPatchGeometry();
+        dx_0 = std::min(dx_0,
+                        *std::min_element(pgeom->getDx(),
+                                          pgeom->getDx() + spacedim));
+      }
+    dx_0 = Utilities::MPI::min(dx_0, tbox::SAMRAI_MPI::getCommunicator());
+    Assert(dx_0 != std::numeric_limits<double>::max(), ExcFDLInternalError());
+    const double target_element_area = std::pow(dx_0, dim - 1);
 
-    // TODO: determine dx here
-    
-    setup_meter_tria(positions, meter_tria, target_element_area);
+    meter_tria.clear();
+    internal::setup_meter_tria(positions, meter_tria, target_element_area);
+
+    scalar_dof_handler.reinit(meter_tria);
+    scalar_dof_handler.distribute_dofs(*scalar_fe);
+    vector_dof_handler.reinit(meter_tria);
+    vector_dof_handler.distribute_dofs(*vector_fe);
+
+    ;
+    const auto local_bboxes = compute_cell_bboxes<dim - 1, spacedim, float>(
+      vector_dof_handler,
+      meter_tria.get_reference_cells()[0]
+        .template get_default_linear_mapping<dim - 1, spacedim>());
+    const auto all_bboxes =
+      collect_all_active_cell_bboxes(meter_tria, local_bboxes);
+
+    // Set up partitioners:
+    {
+      IndexSet vector_locally_relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(vector_dof_handler,
+                                              vector_locally_relevant_dofs);
+      vector_partitioner = std::make_shared<Utilities::MPI::Partitioner>(
+        vector_dof_handler.locally_owned_dofs(),
+        vector_locally_relevant_dofs,
+        vector_dof_handler.get_communicator());
+
+      IndexSet scalar_locally_relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(scalar_dof_handler,
+                                              scalar_locally_relevant_dofs);
+      scalar_partitioner = std::make_shared<Utilities::MPI::Partitioner>(
+        scalar_dof_handler.locally_owned_dofs(),
+        scalar_locally_relevant_dofs,
+        scalar_dof_handler.get_communicator());
+    }
+    LinearAlgebra::distributed::Vector<double> identity_position(
+      vector_partitioner);
+    VectorTools::interpolate(vector_dof_handler,
+                             Functions::IdentityFunction<spacedim>(),
+                             identity_position);
+
+    // TODO we'll need some extra code to guarantee that the box containing
+    // the meter mesh is on the finest level: alternatively, perhaps we can
+    // 'fix' NodalInteraction so that it supports structures on multiple
+    // levels. That shouldn't be too bad since we just need to figure out
+    // which nodes are on the interiors of which patches (much easier than
+    // splitting elements)
+    nodal_interaction = std::make_unique<NodalInteraction<dim - 1, spacedim>>(
+      meter_tria,
+      all_bboxes,
+      // this vector isn't read so we can skip it
+      std::vector<float>(),
+      patch_hierarchy,
+      level_number,
+      vector_dof_handler,
+      identity_position);
+    nodal_interaction->add_dof_handler(scalar_dof_handler);
   }
+
+  template <int dim, int spacedim>
+  Tensor<1, spacedim>
+  MeterMesh<dim, spacedim>::mean_meter_velocity(const int          data_idx,
+                                                const std::string &kernel_name)
+  {
+    Assert(false, ExcFDLNotImplemented());
+    return {};
+  }
+
+  template <int dim, int spacedim>
+  Tensor<1, spacedim>
+  MeterMesh<dim, spacedim>::mean_flux(const int          data_idx,
+                                      const std::string &kernel_name)
+  {
+    Assert(false, ExcFDLNotImplemented());
+    return {};
+  }
+
+  template <int dim, int spacedim>
+  double
+  MeterMesh<dim, spacedim>::mean_value(const int          data_idx,
+                                       const std::string &kernel_name)
+  {
+    Assert(false, ExcFDLNotImplemented());
+    return {};
+  }
+
+
+  template class MeterMesh<NDIM, NDIM>;
+
 } // namespace fdl


### PR DESCRIPTION
WIP - needs some more thought behind the interface. The general workflow should be:
1. Get a node set - for us that's a `std::vector<Point<spacedim>>`
2. use `FEPointEvaluation` to compute the displaced locations of those nodes. Optionally also compute the velocity of the meter itself for use as an offset later (if the meter travels at the mean flow speed then the flux should be zero)
3. use the new triangle interface to generate a mesh from those displaced points.
4. use `NodalInteraction` to interpolate a field onto the meter mesh.
5. compute whatever we need (e.g., flux) from the interpolated field.