### PR TITLE
Clean up the fiber network code a bit.

### DIFF
--- a/include/fiddle/mechanics/fiber_network.h
+++ b/include/fiddle/mechanics/fiber_network.h
@@ -20,6 +20,17 @@ namespace fdl
   public:
     /**
      * Constructor.
+     *
+     * @param tria The Triangulation over which fiber data is defined.
+     * @param fibers The vectors of fibers. The number of entries in each
+     * vector in @p fibers must equal the number of locally owned cells of @p
+     * on the current processor, and values in these vectors are indexed by
+     * the global active cell index (minus the current processor's offset).
+     *
+     * @note It is probably easiest to load this data from a set of scalar
+     * cell data vectors by setting up an FESystem<dim>(FE_SimplexP<dim>,
+     * dim), using the mechanism for loading FE data, and then converting that
+     * data vector into a vector of tensors.
      */
     FiberNetwork(const Triangulation<dim, spacedim>                  &tria,
                  const std::vector<std::vector<Tensor<1, spacedim>>> &fibers);

--- a/source/mechanics/fiber_network.cc
+++ b/source/mechanics/fiber_network.cc
@@ -15,32 +15,27 @@ namespace fdl
     const std::vector<std::vector<Tensor<1, spacedim>>> &fibers)
     : tria(&tria)
   {
-    // initialize local_processor_min_cell_index to maximum value it could be
-    // set to
     local_processor_min_cell_index =
       std::numeric_limits<types::global_cell_index>::max();
+    unsigned int n_locally_owned_cells = 0;
 
     for (const auto &cell : tria.active_cell_iterators())
-      {
-        local_processor_min_cell_index =
-          std::min(local_processor_min_cell_index, cell->active_cell_index());
-      }
+      if (cell->is_locally_owned())
+        {
+          local_processor_min_cell_index =
+            std::min(local_processor_min_cell_index,
+                     cell->global_active_cell_index());
+          ++n_locally_owned_cells;
+        }
 
-    // number of active cells in current processor
-    auto n_table_rows = tria.n_active_cells();
+    for (const auto &fiber_vec : fibers)
+      AssertThrow(n_locally_owned_cells == fiber_vec.size(),
+                  ExcMessage("Not enough tensors in this vector"));
 
-    if (fibers[0].size() > 0)
-      {
-        AssertThrow(
-          n_table_rows == fibers[0].size(),
-          ExcMessage(
-            "fibers vector size should be equal to the number of active cells"));
-      }
-
-    const auto n_table_cols = fibers.size();
-    this->fibers.reinit(n_table_rows, n_table_cols);
-    for (unsigned int i = 0; i < n_table_rows; ++i)
-      for (unsigned int j = 0; j < n_table_cols; ++j)
+    const auto n_fiber_networks = fibers.size();
+    this->fibers.reinit(n_locally_owned_cells, n_fiber_networks);
+    for (unsigned int j = 0; j < n_fiber_networks; ++j)
+      for (unsigned int i = 0; i < n_locally_owned_cells; ++i)
         this->fibers(i, j) = fibers[j][i];
   }
 


### PR DESCRIPTION
`global_active_cell_index()` is now used everywhere. We still need to write some parallel tests.