### PR TITLE
Mechanics value postprocessor

### DIFF
--- a/include/fiddle/mechanics/mechanics_values.h
+++ b/include/fiddle/mechanics/mechanics_values.h
@@ -191,9 +191,30 @@ namespace fdl
                     const VectorType                  &velocity,
                     const MechanicsUpdateFlags         flags);
 
+    /**
+     * Alternate constructor which relies on the reinit() function which takes
+     * precomputed values of FF. This is useful when working with postprocessors
+     * but does not support computing positions, velocities, or normal vectors.
+     */
+    MechanicsValues(const MechanicsUpdateFlags flags);
+
+    /**
+     * Reinitialization function which updates values on a new cell.
+     */
     template <typename Iterator>
     void
     reinit(const Iterator &cell);
+
+    /**
+     * Reinitialization function which updates values from a specified set of
+     * deformation gradients. This is intended for use with deal.II's
+     * postprocessors which compute values at somewhat arbitrary points.
+     *
+     * @note This reinit() function cannot be used when the present object is
+     * set up to compute displacements, velocities, or deformed normal vectors.
+     */
+    void
+    reinit(const std::vector<Tensor<2, spacedim>> &provided_FF);
 
     const FEValuesBase<dim, spacedim> &
     get_fe_values() const;
@@ -250,6 +271,18 @@ namespace fdl
     get_modified_first_invariant_dFF() const;
 
   protected:
+    /**
+     * Resize all arrays.
+     */
+    void
+    resize(std::size_t size);
+
+    /**
+     * Reinitialize all values dependent on FF (the deformation gradient).
+     */
+    void
+    reinit_from_FF();
+
     SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     SmartPointer<const VectorType> position;

--- a/tests/mechanics/pk1_volumetric_04.cc
+++ b/tests/mechanics/pk1_volumetric_04.cc
@@ -78,8 +78,12 @@ test(const Mapping<dim, spacedim>                     &mapping,
                                       position,
                                       velocity,
                                       stress.get_mechanics_update_flags());
+  // also test the alternative reinitialization mechanism for MechanicsValues
+  fdl::MechanicsValues<dim> me_values_2(stress.get_mechanics_update_flags());
+
 
   std::vector<Tensor<2, dim>> stresses(quadrature.size());
+  std::vector<Tensor<2, dim>> stresses_2(quadrature.size());
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
       fe_values.reinit(cell);
@@ -92,6 +96,12 @@ test(const Mapping<dim, spacedim>                     &mapping,
              << std::endl;
       for (const auto &stress : stresses)
         output << "  " << stress << std::endl;
+
+      // and the other one
+      me_values_2.reinit(me_values.get_FF());
+      auto view_2 = make_array_view(stresses_2.begin(), stresses_2.end());
+      stress.compute_stress(0.0, me_values_2, cell, view_2);
+      AssertThrow(stresses == stresses_2, ExcMessage("Should be equal"));
     }
 }
 


### PR DESCRIPTION
These changes make it possible to use MechanicsValues with the input provided by a deal.II postprocessor for most things - very convenient. We need it for computing Cauchy stresses.