### PR TITLE
Use 'volatile' in Triangle.

### DIFF
--- a/source/grid/triangle.c
+++ b/source/grid/triangle.c
@@ -272,8 +272,8 @@
 /* #define CPU86 */
 /* #define LINUX */
 
-#define INEXACT /* Nothing */
-/* #define INEXACT volatile */
+/* #define INEXACT /\* Nothing *\/ */
+#define INEXACT volatile
 
 /* Maximum number of characters in a file name (including the null).         */
 

--- a/tests/postprocess/meter_mesh_02.cc
+++ b/tests/postprocess/meter_mesh_02.cc
@@ -82,7 +82,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
           bounding_disk_vertex_indices.insert(face->vertex_index(vertex_n));
 
   // Avoid issues with roundoff in Triangle by perturbing vertices slightly
-  GridTools::distort_random(0.4, tria, false);
+  GridTools::distort_random(0.1, tria, false);
 
   std::vector<Point<spacedim>> bounding_disk_points;
   for (const unsigned int vertex_n : bounding_disk_vertex_indices)

--- a/tests/postprocess/meter_mesh_02.output
+++ b/tests/postprocess/meter_mesh_02.output
@@ -1,8 +1,8 @@
 number of hull points = 16
-number of vertices = 94
-number of active cells = 170
-centroid = 0.404308 0.401403 0.395646
-global error in F = 0.123546
-computed mean velocity = -0.346229 0.0603258 0.0533293
-   meter mean velocity = -0.346229 0.0603258 0.0533293
-global error in mean velocity = 4.17982e-15
+number of vertices = 97
+number of active cells = 176
+centroid = 0.400979 0.400365 0.399012
+global error in F = 0.122002
+computed mean velocity = -0.36567 0.0630565 0.0595543
+   meter mean velocity = -0.36567 0.0630565 0.0595543
+global error in mean velocity = 6.54199e-15


### PR DESCRIPTION
Not the best solution, but this makes things work correctly with triangle's very precise floating point routines. Doing

SET_SOURCE_FILES_PROPERTIES(source/grid/triangle.c PROPERTIES COMPILE_OPTIONS "-mno-default;-g;-O0;-mpc64;-mfpmath=387;-mieee-fp")

Wasn't enough, perhaps because CMAKE_CXX_FLAGS is still present (or that set of flags isn't sufficient to fully eliminate 80-bit temporaries).