### PR TITLE
Check if a SurfaceMeter was set up with a codim 0 mesh.

### DIFF
--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -101,6 +101,12 @@ namespace fdl
       tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
+     * Whether or not the SurfaceMeter was set up with a codimension zero mesh.
+     */
+    bool
+    uses_codim_zero_mesh() const;
+
+    /**
      * Reinitialize the meter mesh to have its coordinates specified by @p
      * position and velocity by @p velocity.
      *

--- a/source/postprocess/surface_meter.cc
+++ b/source/postprocess/surface_meter.cc
@@ -142,11 +142,22 @@ namespace fdl
   }
 
   template <int dim, int spacedim>
+  bool
+  SurfaceMeter<dim, spacedim>::uses_codim_zero_mesh() const
+  {
+      return position_dof_handler != nullptr;
+  }
+
+  template <int dim, int spacedim>
   void
   SurfaceMeter<dim, spacedim>::reinit(
     const LinearAlgebra::distributed::Vector<double> &position,
     const LinearAlgebra::distributed::Vector<double> &velocity)
   {
+    Assert(uses_codim_zero_mesh(),
+           ExcMessage("This function cannot be called when the SurfaceMeter is "
+                      "set up without an underlying codimension zero "
+                      "Triangulation."));
     // Reset the meter mesh according to the new position values:
     const std::vector<Tensor<1, spacedim>> position_values =
       point_values->evaluate(position);
@@ -165,6 +176,10 @@ namespace fdl
     const std::vector<Point<spacedim>>     &boundary_points,
     const std::vector<Tensor<1, spacedim>> &velocity_values)
   {
+    Assert(!uses_codim_zero_mesh(),
+           ExcMessage("This function may only be called when the SurfaceMeter "
+                      "is set up without an underlying codimension zero "
+                      "Triangulation."));
     reinit_tria(boundary_points, true);
     reinit_mean_velocity(velocity_values);
   }

--- a/tests/postprocess/meter_mesh_01.cc
+++ b/tests/postprocess/meter_mesh_01.cc
@@ -73,6 +73,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
   fdl::SurfaceMeter<dim, spacedim> meter_mesh(convex_hull,
                                               velocities,
                                               patch_hierarchy);
+  AssertThrow(!meter_mesh.uses_codim_zero_mesh(), fdl::ExcFDLInternalError());
 
   // do the actual test:
   const double interpolated_mean_value =

--- a/tests/postprocess/meter_mesh_02.cc
+++ b/tests/postprocess/meter_mesh_02.cc
@@ -110,6 +110,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
                                               patch_hierarchy,
                                               position,
                                               velocity);
+  AssertThrow(meter_mesh.uses_codim_zero_mesh(), fdl::ExcFDLInternalError());
 
   std::ofstream output;
   if (rank == 0)


### PR DESCRIPTION
We need this in the heart model so that we can call the correct reinitialization function while still managing meters in a generic way.