### PR TITLE
Move Scatter objects instead of copying them.

### DIFF
--- a/include/fiddle/transfer/scatter.h
+++ b/include/fiddle/transfer/scatter.h
@@ -37,6 +37,17 @@ namespace fdl
     Scatter() = default;
 
     /**
+     * Move constructor.
+     */
+    Scatter(Scatter<T> &&) = default;
+
+    /**
+     * Move assignment.
+     */
+    Scatter<T> &
+    operator=(Scatter<T> &&) = default;
+
+    /**
      * Constructor.
      */
     Scatter(const std::vector<types::global_dof_index> &overlap,

--- a/source/interaction/interaction_base.cc
+++ b/source/interaction/interaction_base.cc
@@ -232,7 +232,7 @@ namespace fdl
     if (index >= scatters.size())
       scatters.resize(index + 1);
     std::vector<Scatter<double>> &this_dh_scatters = scatters[index];
-    this_dh_scatters.emplace_back(scatter);
+    this_dh_scatters.emplace_back(std::move(scatter));
   }
 
 


### PR DESCRIPTION
Fixes #144.