### PR TITLE
Conditional velocity ghost update

### DIFF
--- a/include/fiddle/mechanics/part_vectors.h
+++ b/include/fiddle/mechanics/part_vectors.h
@@ -23,6 +23,12 @@ namespace fdl
    * beginning of the timestep, but by the end of the timestep we will also have
    * it at the end. This class provides some basic checking to make sure we only
    * access vectors that exist at the requested time.
+   *
+   * The major operations done at each timestep, namely IB operations and
+   * linear algebra, do not require ghost values. Hence this class will always
+   * set stored vectors to 'unghosted' to avoid extra communication. If you
+   * need ghost values then you will need to call the relevant functions as
+   * needed.
    */
   template <int dim, int spacedim = dim>
   class PartVectors

--- a/include/fiddle/transfer/scatter.h
+++ b/include/fiddle/transfer/scatter.h
@@ -39,13 +39,13 @@ namespace fdl
     /**
      * Move constructor.
      */
-    Scatter(Scatter<T> &&) = default;
+    Scatter(Scatter<T> &&);
 
     /**
      * Move assignment.
      */
     Scatter<T> &
-    operator=(Scatter<T> &&) = default;
+    operator=(Scatter<T> &&);
 
     /**
      * Constructor.
@@ -100,5 +100,26 @@ namespace fdl
 
     LinearAlgebra::distributed::Vector<T> scatterer;
   };
+
+
+  //
+  // inline functions
+  //
+
+  template <typename T>
+  Scatter<T>::Scatter(Scatter<T> &&t)
+  {
+    overlap_dofs.swap(t.overlap_dofs);
+    scatterer.swap(t.scatterer);
+  }
+
+  template <typename T>
+  Scatter<T> &
+  Scatter<T>::operator=(Scatter<T> &&t)
+  {
+    overlap_dofs.swap(t.overlap_dofs);
+    scatterer.swap(t.scatterer);
+    return *this;
+  }
 } // namespace fdl
 #endif

--- a/source/interaction/ifed_method.cc
+++ b/source/interaction/ifed_method.cc
@@ -735,15 +735,22 @@ namespace fdl
     this->half_time    = std::numeric_limits<double>::quiet_NaN();
 
     // update positions and velocities:
-    auto do_set = [](auto &collection, auto &positions, auto &velocities)
+    unsigned int channel = 0;
+    auto do_set = [&](auto &collection, auto &positions, auto &velocities)
     {
       for (unsigned int i = 0; i < collection.size(); ++i)
         {
           auto &part = collection[i];
           part.set_position(std::move(positions[i]));
-          part.get_position().update_ghost_values();
+          part.get_position().update_ghost_values_start(channel++);
           part.set_velocity(std::move(velocities[i]));
-          part.get_velocity().update_ghost_values();
+          part.get_velocity().update_ghost_values_start(channel++);
+        }
+      for (unsigned int i = 0; i < collection.size(); ++i)
+        {
+          auto &part = collection[i];
+          part.get_position().update_ghost_values_finish();
+          part.get_velocity().update_ghost_values_finish();
         }
     };
     auto new_positions  = part_vectors.get_all_new_positions();
@@ -773,14 +780,15 @@ namespace fdl
                       ExcFDLInternalError());
           // Set the position at the end time:
           LinearAlgebra::distributed::Vector<double> new_position(
-            part.get_partitioner());
-          new_position = part.get_position();
+            part.get_position());
+          new_position.set_ghost_state(false);
           new_position.add(dt, part.get_velocity());
           vectors.set_position(i, new_time, std::move(new_position));
 
           // Set the position at the half time:
           LinearAlgebra::distributed::Vector<double> half_position(
             part.get_partitioner());
+          half_position.set_ghost_state(false);
           half_position.add(0.5,
                             vectors.get_position(i, current_time),
                             0.5,
@@ -816,14 +824,15 @@ namespace fdl
                       ExcFDLInternalError());
           // Set the position at the end time:
           LinearAlgebra::distributed::Vector<double> new_position(
-            part.get_partitioner());
-          new_position = part.get_position();
+            part.get_position());
+          new_position.set_ghost_state(false);
           new_position.add(dt, vectors.get_velocity(i, half_time));
           vectors.set_position(i, new_time, std::move(new_position));
 
           // Set the position at the half time:
           LinearAlgebra::distributed::Vector<double> half_position(
             part.get_partitioner());
+          half_position.set_ghost_state(false);
           half_position.add(0.5,
                             vectors.get_position(i, current_time),
                             0.5,
@@ -855,9 +864,18 @@ namespace fdl
   {
     IBAMR_TIMER_START(t_compute_lagrangian_force);
 
+    unsigned int channel = 0;
     auto do_load =
       [&](auto &collection, auto &vectors, auto &forces, auto &right_hand_sides)
     {
+      // Unlike velocity interpolation and force spreading we actually need
+      // the ghost values in the native partitioning, so make sure they are
+      // available
+      for (unsigned int i = 0; i < collection.size(); ++i)
+        vectors.get_position(i, data_time).update_ghost_values_start(channel++);
+      for (unsigned int i = 0; i < collection.size(); ++i)
+        vectors.get_position(i, data_time).update_ghost_values_finish();
+
       for (unsigned int i = 0; i < collection.size(); ++i)
         {
           const auto &part = collection[i];
@@ -866,15 +884,11 @@ namespace fdl
           forces.emplace_back(part.get_partitioner());
           right_hand_sides.emplace_back(part.get_partitioner());
 
-          // The velocity isn't available at data_time so use current_time -
-          // IBFEMethod does this too.
           const auto &position = vectors.get_position(i, data_time);
-          const auto &velocity = vectors.get_velocity(i, current_time);
-          // Unlike velocity interpolation and force spreading we actually need
-          // the ghost values in the native partitioning, so make sure they are
-          // available
-          position.update_ghost_values();
-          velocity.update_ghost_values();
+          // The velocity isn't available at data_time so use current_time -
+          // IBFEMethod does this too. This is always equal to the part's
+          // current velocity and, by convention, has up-to-date ghost values.
+          const auto &velocity = part.get_velocity();
           for (auto &force : part.get_force_contributions())
             force->setup_force(data_time, position, velocity);
           for (auto &active_strain : part.get_active_strains())

--- a/source/interaction/ifed_method.cc
+++ b/source/interaction/ifed_method.cc
@@ -685,7 +685,7 @@ namespace fdl
           const auto local_bboxes =
             compute_cell_bboxes<structdim, spacedim, float>(
               part.get_dof_handler(), mapping);
-          // Like most other things this only works with p::S::T now
+          // Like most other things this only works with p::s::T now
           const auto &tria = dynamic_cast<
             const parallel::shared::Triangulation<structdim, spacedim> &>(
             part.get_triangulation());

--- a/source/mechanics/part_vectors.cc
+++ b/source/mechanics/part_vectors.cc
@@ -119,6 +119,7 @@ namespace fdl
     LinearAlgebra::distributed::Vector<double> position)
   {
     AssertIndexRange(part_n, parts.size());
+    position.set_ghost_state(false);
     switch (get_time_step(time))
       {
         case TimeStep::Current:
@@ -171,6 +172,7 @@ namespace fdl
     LinearAlgebra::distributed::Vector<double> velocity)
   {
     AssertIndexRange(part_n, parts.size());
+    velocity.set_ghost_state(false);
     switch (get_time_step(time))
       {
         case TimeStep::Current:
@@ -225,6 +227,7 @@ namespace fdl
     LinearAlgebra::distributed::Vector<double> force)
   {
     AssertIndexRange(part_n, parts.size());
+    force.set_ghost_state(false);
     switch (get_time_step(time))
       {
         case TimeStep::Current:

--- a/tests/interaction/ifed_spread_01.cc
+++ b/tests/interaction/ifed_spread_01.cc
@@ -93,11 +93,6 @@ public:
     this->part_vectors.set_force(0,
                                  this->current_time,
                                  std::move(current_force));
-    // Check that we don't have a bug that existed prior to about June of 2021
-    // w.r.t. move ctors and LA::d::V
-    Assert(
-      this->part_vectors.get_force(0, this->current_time).has_ghost_elements(),
-      ExcMessage("Should have ghosts"));
   }
 
   // just for testing - plot the force
@@ -320,9 +315,9 @@ test(tbox::Pointer<IBTK::AppInitializer> app_initializer)
       const auto  &part = ifed_method.get_part(0);
       DataOut<dim> data_out;
       data_out.attach_dof_handler(part.get_dof_handler());
-      data_out.add_data_vector(ifed_method.get_force(), "F");
-      Assert(ifed_method.get_force().has_ghost_elements(),
-             ExcMessage("Should have ghosts"));
+      auto &force = ifed_method.get_force();
+      force.update_ghost_values();
+      data_out.add_data_vector(force, "F");
 
       MappingFEField<dim, spacedim, LinearAlgebra::distributed::Vector<double>>
         position_mapping(part.get_dof_handler(), part.get_position());


### PR DESCRIPTION
Fixes #143, #145, #146. Part of #142.

With a little work (maybe two hours?) we can make, for the Turek-Hron benchmark:
- interpolateVelocity() about 15% faster
- spreadForce() about 10% faster
- `forwardEulerStep()` and `mindpointStep()` about 3x faster

just by avoiding some copies and being more careful with ghost updates.