### PR TITLE
Return the normal vector with the flux.

### DIFF
--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -18,6 +18,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace fdl
@@ -219,10 +220,18 @@ namespace fdl
     compute_mean_value(const int data_idx, const std::string &kernel_name);
 
     /**
-     * Compute the flux of some quantity through the meter mesh.
+     * Compute both the flux and the flux of some quantity through the meter
+     * mesh and the mean normal vector of the mesh.
+     *
+     * @note The normal vector's sign depends on the orientation of the
+     * Triangulation - see the deal.II glossary entry on "Direction flags" for
+     * more information. This value is well-defined but might have the wrong
+     * sign for your application. For example, if a meter is at a boundary and
+     * you want to measure outflow, then you should check that the normal vector
+     * points out of the domain.
      */
-    virtual double
-    compute_flux(const int data_idx, const std::string &kernel_name);
+    virtual std::pair<double, Tensor<1, spacedim>>
+    compute_flux(const int data_idx, const std::string &kernel_name) const;
 
     /**
      * Interpolate the value of some scalar field at the centroid.

--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -234,6 +234,13 @@ namespace fdl
     compute_flux(const int data_idx, const std::string &kernel_name) const;
 
     /**
+     * Compute the mean normal vector. This is useful for checking the
+     * orientation of the mesh.
+     */
+    virtual Tensor<1, spacedim>
+    compute_mean_normal_vector() const;
+
+    /**
      * Interpolate the value of some scalar field at the centroid.
      */
     virtual double
@@ -267,7 +274,8 @@ namespace fdl
     /**
      * Reinitialize all the FE data structures, including vectors and mappings.
      */
-    void reinit_dofs();
+    void
+    reinit_dofs();
 
     /**
      * Reinitialize the NodalInteraction object.

--- a/source/postprocess/surface_meter.cc
+++ b/source/postprocess/surface_meter.cc
@@ -577,9 +577,10 @@ namespace fdl
   }
 
   template <int dim, int spacedim>
-  double
-  SurfaceMeter<dim, spacedim>::compute_flux(const int          data_idx,
-                                            const std::string &kernel_name)
+  std::pair<double, Tensor<1, spacedim>>
+  SurfaceMeter<dim, spacedim>::compute_flux(
+    const int          data_idx,
+    const std::string &kernel_name) const
   {
     const auto interpolated_data =
       interpolate_vector_field(data_idx, kernel_name);
@@ -594,6 +595,7 @@ namespace fdl
     std::vector<types::global_dof_index> cell_dofs(fe.dofs_per_cell);
     std::vector<Tensor<1, spacedim>>     cell_values(meter_quadrature.size());
     double                               flux = 0.0;
+    Tensor<1, spacedim>                  mean_normal;
     for (const auto &cell : get_vector_dof_handler().active_cell_iterators() |
                               IteratorFilters::LocallyOwnedCell())
       {
@@ -602,11 +604,18 @@ namespace fdl
         fe_values[FEValuesExtractors::Vector(0)].get_function_values(
           interpolated_data, cell_values);
         for (unsigned int q = 0; q < meter_quadrature.size(); ++q)
-          flux +=
-            cell_values[q] * fe_values.normal_vector(q) * fe_values.JxW(q);
+          {
+            flux +=
+              cell_values[q] * fe_values.normal_vector(q) * fe_values.JxW(q);
+            mean_normal += fe_values.normal_vector(q) * fe_values.JxW(q);
+          }
       }
 
-    return Utilities::MPI::sum(flux, meter_tria.get_communicator());
+    flux = Utilities::MPI::sum(flux, meter_tria.get_communicator());
+    mean_normal =
+      Utilities::MPI::sum(mean_normal, meter_tria.get_communicator());
+    mean_normal /= mean_normal.norm();
+    return std::make_pair(flux, mean_normal);
   }
 
   template <int dim, int spacedim>

--- a/tests/interaction/ifed_ex4.cc
+++ b/tests/interaction/ifed_ex4.cc
@@ -423,7 +423,7 @@ test(tbox::Pointer<IBTK::AppInitializer> app_initializer)
           // use better kernels than PIECEWISE_CONSTANT. This approach
           // suffices for testing that we can do very basic meter stuff.
 
-          auto *    var_db = hier::VariableDatabase<spacedim>::getDatabase();
+          auto     *var_db = hier::VariableDatabase<spacedim>::getDatabase();
           const int u_current_idx = var_db->mapVariableAndContextToIndex(
             navier_stokes_integrator->getVelocityVariable(),
             navier_stokes_integrator->getCurrentContext());
@@ -475,12 +475,14 @@ test(tbox::Pointer<IBTK::AppInitializer> app_initializer)
           tbox::pout << "meter 2 centroid = " << surface_meter_2->get_centroid()
                      << std::endl;
           tbox::pout << "meter 1 flux = "
-                     << surface_meter_1->compute_flux(u_scratch_idx,
-                                                      "PIECEWISE_CONSTANT")
+                     << surface_meter_1
+                          ->compute_flux(u_scratch_idx, "PIECEWISE_CONSTANT")
+                          .first
                      << std::endl;
           tbox::pout << "meter 2 flux = "
-                     << surface_meter_2->compute_flux(u_scratch_idx,
-                                                      "PIECEWISE_CONSTANT")
+                     << surface_meter_2
+                          ->compute_flux(u_scratch_idx, "PIECEWISE_CONSTANT")
+                          .first
                      << std::endl;
 
           for (int ln = coarsest_ln; ln <= finest_ln; ++ln)

--- a/tests/postprocess/meter_mesh_02.cc
+++ b/tests/postprocess/meter_mesh_02.cc
@@ -247,7 +247,9 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
     const auto   flux_pair  = meter_mesh.compute_flux(f_idx, "BSPLINE_3");
     const double meter_flux = flux_pair.first;
     const Tensor<1, spacedim> meter_normal = flux_pair.second;
-    const double              meter_centroid_g =
+    const Tensor<1, spacedim> other_meter_normal =
+      meter_mesh.compute_mean_normal_vector();
+    const double meter_centroid_g =
       meter_mesh.compute_centroid_value(g_idx, "BSPLINE_3");
     if (rank == 0)
       output << "number of hull points = " << bounding_disk_points.size()
@@ -268,6 +270,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
              << "computed flux = " << flux << std::endl
              << "   meter flux = " << meter_flux << std::endl
              << "   meter normal = " << meter_normal << std::endl
+             << "   meter normal = " << other_meter_normal << std::endl
              << std::endl
              << "global error in mean velocity = "
              << (mean_velocity - meter_mesh.get_mean_velocity()).norm()

--- a/tests/postprocess/meter_mesh_02.cc
+++ b/tests/postprocess/meter_mesh_02.cc
@@ -244,8 +244,10 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
         mean_velocity /= area;
       }
 
-    const double meter_flux = meter_mesh.compute_flux(f_idx, "BSPLINE_3");
-    const double meter_centroid_g =
+    const auto   flux_pair  = meter_mesh.compute_flux(f_idx, "BSPLINE_3");
+    const double meter_flux = flux_pair.first;
+    const Tensor<1, spacedim> meter_normal = flux_pair.second;
+    const double              meter_centroid_g =
       meter_mesh.compute_centroid_value(g_idx, "BSPLINE_3");
     if (rank == 0)
       output << "number of hull points = " << bounding_disk_points.size()
@@ -265,6 +267,7 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
              << std::endl
              << "computed flux = " << flux << std::endl
              << "   meter flux = " << meter_flux << std::endl
+             << "   meter normal = " << meter_normal << std::endl
              << std::endl
              << "global error in mean velocity = "
              << (mean_velocity - meter_mesh.get_mean_velocity()).norm()

--- a/tests/postprocess/meter_mesh_02.output
+++ b/tests/postprocess/meter_mesh_02.output
@@ -11,5 +11,6 @@ computed mean velocity = -0.36567 0.0630565 0.0595543
 computed flux = -0.00554962
    meter flux = -0.00555945
    meter normal = -0.00618519 -0.00403823 0.999973
+   meter normal = -0.00618519 -0.00403823 0.999973
 
 global error in mean velocity = 6.39292e-15

--- a/tests/postprocess/meter_mesh_02.output
+++ b/tests/postprocess/meter_mesh_02.output
@@ -10,5 +10,6 @@ computed mean velocity = -0.36567 0.0630565 0.0595543
    meter mean velocity = -0.36567 0.0630565 0.0595543
 computed flux = -0.00554962
    meter flux = -0.00555945
+   meter normal = -0.00618519 -0.00403823 0.999973
 
-global error in mean velocity = 6.54199e-15
+global error in mean velocity = 6.39292e-15


### PR DESCRIPTION
A problem we have in the heart model is that these surface meshes have well-defined but arbitrary (it depends on deal.II internals and the order of nodes in the nodeset) orientation. Hence we need a way to check at, e.g., an outflow, if the flux is the flux into the domain or out of it.

We already loop across the cells when we compute the flux so computing the mean normal vector is no more expensive than what we already have. Lets return it with the flux and let the caller decide if the sign should be flipped.