### PR TITLE
Start drafting PatchIntersectionMap.

### DIFF
--- a/include/fiddle/grid/patch_intersection_map.h
+++ b/include/fiddle/grid/patch_intersection_map.h
@@ -1,0 +1,396 @@
+#ifndef included_fiddle_grid_intersection_map_h
+#define included_fiddle_grid_intersection_map_h
+
+#include <fiddle/base/config.h>
+
+#include <fiddle/base/exceptions.h>
+
+#include <fiddle/grid/patch_map.h>
+
+#include <deal.II/base/linear_index_iterator.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+FDL_DISABLE_EXTRA_DIAGNOSTICS
+#include <CellIndex.h>
+#include <Patch.h>
+#include <SideIndex.h>
+FDL_ENABLE_EXTRA_DIAGNOSTICS
+
+#include <iterator>
+
+namespace fdl
+{
+  using namespace dealii;
+  using namespace SAMRAI;
+
+  namespace internal
+  {
+    /**
+     * Storage of intersections between a single Patch and the displaced
+     * elements. This class only stores single intersections: i.e., it assumes
+     * each stored stencil only intersects a mesh exactly once.
+     *
+     * The intersections are stored in a compressed format:
+     *
+     * 1. As intersections are defined as pairs of adjacent cell indices, it
+     *    suffices to store the lower index and the axis. To get the upper index
+     *    we just increment the entry of the lower index corresponding to its
+     *    axis.
+     *
+     * 2. A CellIndex, dx (grid spacing), and domain_x_lower together uniquely
+     *    define the Cartesian coordinates of a point. Hence we store the
+     *    Cartesian coordinates of the intersections themselves as convex
+     *    combinations of the lower and upper points.
+     *
+     * 3. In the usual deal.II way we can construct Triangulation or DoFHandler
+     *    iterators on-the-fly via the TriaIterator constructor (which only
+     *    requires pointers to the Triangulation and DoFHandler, the cell level,
+     *    and the cell index).
+     *
+     * As the maximum value for an axis is 2 and the maximum possible value for
+     * a level is perhaps 20-30 (as the number of cells scales exponentially
+     * with the level) it suffices to store both as unsigned chars to save a lot
+     * of memory.
+     *
+     * As the name implies, this is only presently implemented for stencils
+     * which intersect the FE mesh exactly once. Handling multiple intersections
+     * is a future project.
+     */
+    template <int spacedim>
+    struct PatchSingleIntersections
+    {
+      // Eulerian grid spacing.
+      Tensor<1, spacedim> dx;
+
+      // Bottom left corner of the domain.
+      Point<spacedim> domain_x_lower;
+
+      // lower index of each intersection.
+      std::vector<pdat::CellIndex<spacedim>> lower_indices;
+
+      // axis of each intersection.
+      std::vector<unsigned char> axes;
+
+      // convex combination coefficient of each intersection.
+      std::vector<double> convex_coefficients;
+
+      // deal.II cell level.
+      std::vector<unsigned char> cell_level;
+
+      // deal.II cell index.
+      std::vector<int> cell_index;
+    };
+  } // namespace internal
+
+  /**
+   * Mapping between patches, elements, and the points at which finite
+   * difference stencils intersect elements.
+   *
+   * @note This class presently only supports cell and side centered data as
+   * those data centerings produce the same intersections.
+   */
+  template <int dim, int spacedim = dim>
+  class PatchIntersectionMap
+  {
+  public:
+    static_assert(dim + 1 == spacedim, "Only implemented for codim = 1");
+
+    class Accessor;
+    class Iterator;
+
+    /**
+     * Default constructor. Sets up an empty mapping.
+     */
+    PatchIntersectionMap() = default;
+
+    /**
+     * Proxy class granting access to an intersection.
+     *
+     * In fiddle, intersections are always defined with pairs of indices: i.e.,
+     * stencils between two cell centers or (for, e.g., side-centered data)
+     * stencils across a single cell.
+     */
+    class Accessor
+    {
+    public:
+      /**
+       * Type of pointer to the container. Required by LinearIndexIterator.
+       */
+      using container_pointer_type =
+        const internal::PatchSingleIntersections<spacedim> *;
+
+      /**
+       * Size type. Required by LinearIndexIterator.
+       */
+      using size_type = std::size_t;
+
+      /**
+       * Constructor.
+       */
+      Accessor(const container_pointer_type container,
+               const std::ptrdiff_t         index);
+
+      /**
+       * Constructor.
+       */
+      Accessor();
+
+      /**
+       * Return the lower cell intersection index.
+       */
+      pdat::CellIndex<spacedim>
+      get_cell_lower() const;
+
+      /**
+       * Return the upper cell intersection index.
+       */
+      pdat::CellIndex<spacedim>
+      get_cell_upper() const;
+
+      /**
+       * Return the lower side intersection index.
+       */
+      pdat::SideIndex<spacedim>
+      get_side_lower() const;
+
+      /**
+       * Return the upper side intersection index.
+       */
+      pdat::SideIndex<spacedim>
+      get_side_upper() const;
+
+      /**
+       * Return the axis of the intersection.
+       *
+       * @note This is equivalent to get_side_lower().getAxis().
+       */
+      int
+      get_axis() const;
+
+      /**
+       * Return the convex combination coefficient defining the location of the
+       * point between the lower and upper CellIndex.
+       */
+      double
+      get_cell_convex_coefficient() const;
+
+      /**
+       * Return the convex combination coefficient defining the location of the
+       * point between the lower and upper SideIndex.
+       */
+      double
+      get_side_convex_coefficient() const;
+
+      /**
+       * Return the actual point of the intersection.
+       */
+      Point<spacedim>
+      get_point() const;
+
+    protected:
+      void
+      assert_valid() const;
+
+      container_pointer_type container;
+
+      std::ptrdiff_t linear_index;
+
+      friend class LinearIndexIterator<Iterator, Accessor>;
+    };
+
+    class Iterator : public LinearIndexIterator<Iterator, Accessor>
+    {
+    public:
+      Iterator(const internal::PatchSingleIntersections<spacedim> *container,
+               const std::ptrdiff_t                                index);
+    };
+
+  protected:
+    PatchMap<dim, spacedim> patch_map;
+  };
+
+
+  // --------------------------- inline functions --------------------------- //
+
+
+  template <int dim, int spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::Accessor(
+    const internal::PatchSingleIntersections<spacedim> *container,
+    const std::ptrdiff_t                                index)
+    : container(container)
+    , linear_index(index)
+  {}
+
+
+
+  template <int dim, int spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::Accessor()
+    : container(nullptr)
+    , linear_index(std::numeric_limits<std::ptrdiff_t>::max())
+  {}
+
+
+
+  template <int dim, int spacedim>
+  void
+  PatchIntersectionMap<dim, spacedim>::Accessor::assert_valid() const
+  {
+    Assert(container, ExcMessage("The pointer should be set."));
+    AssertIndexRange(linear_index, container->lower_indices.size());
+
+    // Also verify PatchSingleIntersections
+    AssertDimension(container->lower_indices.size(), container->axes.size());
+    AssertDimension(container->lower_indices.size(),
+                    container->convex_coefficients.size());
+    AssertDimension(container->lower_indices.size(),
+                    container->cell_level.size());
+    AssertDimension(container->lower_indices.size(),
+                    container->cell_index.size());
+
+    // Check that the convex combination is, in fact, convex
+    const auto convex = container->convex_coefficients[linear_index];
+    (void)convex;
+    Assert(0.0 <= convex && convex <= 1.0,
+           ExcMessage(
+             "The convex combination coefficient should be between 0 and 1."));
+  }
+
+
+
+  template <int dim, int spacedim>
+  pdat::CellIndex<spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_cell_lower() const
+  {
+    assert_valid();
+
+    return container->lower_indices[linear_index];
+  }
+
+
+
+  template <int dim, int spacedim>
+  pdat::CellIndex<spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_cell_upper() const
+  {
+    assert_valid();
+
+    auto cell_index = container->lower_indices[linear_index];
+    ++cell_index(int(container->axes[linear_index]));
+
+    return cell_index;
+  }
+
+
+
+  template <int dim, int spacedim>
+  pdat::SideIndex<spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_side_lower() const
+  {
+    assert_valid();
+
+    // Like in IBAMR, if a point is on the interface between two cells we assign
+    // it to the higher-index cell.
+    const bool in_lower_cell = get_cell_convex_coefficient() < 0.5;
+
+    return pdat::SideIndex<spacedim>(in_lower_cell ? get_cell_lower() :
+                                                     get_cell_upper(),
+                                     get_axis(),
+                                     pdat::SideIndex<spacedim>::Lower);
+  }
+
+
+
+  template <int dim, int spacedim>
+  pdat::SideIndex<spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_side_upper() const
+  {
+    assert_valid();
+
+    const bool in_lower_cell =
+      container->convex_coefficients[linear_index] < 0.5;
+
+    return pdat::SideIndex<spacedim>(in_lower_cell ? get_cell_lower() :
+                                                     get_cell_upper(),
+                                     get_axis(),
+                                     pdat::SideIndex<spacedim>::Upper);
+  }
+
+
+
+  template <int dim, int spacedim>
+  int
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_axis() const
+  {
+    assert_valid();
+
+    return container->axes[linear_index];
+  }
+
+
+
+  template <int dim, int spacedim>
+  double
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_cell_convex_coefficient()
+    const
+  {
+    assert_valid();
+
+    return container->convex_coefficients[linear_index];
+  }
+
+
+
+  template <int dim, int spacedim>
+  double
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_side_convex_coefficient()
+    const
+  {
+    assert_valid();
+
+    const double cell_convex   = get_cell_convex_coefficient();
+    const bool   in_lower_cell = cell_convex < 0.5;
+
+    if (in_lower_cell)
+      {
+        return cell_convex + 0.5;
+      }
+    else
+      {
+        return cell_convex - 0.5;
+      }
+  }
+
+
+
+  template <int dim, int spacedim>
+  Point<spacedim>
+  PatchIntersectionMap<dim, spacedim>::Accessor::get_point() const
+  {
+    assert_valid();
+
+    const auto      cell_index = get_cell_lower();
+    const auto      dx         = container->dx;
+    Point<spacedim> result     = container->domain_x_lower;
+
+    for (unsigned int d = 0; d < spacedim; ++d)
+      result[d] += (double(cell_index(d)) + 0.5) * dx[d];
+
+    result[get_axis()] += dx[get_axis()] * get_cell_convex_coefficient();
+
+    return result;
+  }
+
+
+
+  template <int dim, int spacedim>
+  PatchIntersectionMap<dim, spacedim>::Iterator::Iterator(
+    const internal::PatchSingleIntersections<spacedim> *container,
+    const std::ptrdiff_t                                index)
+    : LinearIndexIterator<Iterator, Accessor>(
+        PatchIntersectionMap<dim, spacedim>::Accessor(container, index))
+  {}
+} // namespace fdl
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ SETUP(grid grid_predicate_01.cc fiddle2d)
 SETUP(grid nonoverlapping_boxes_01.cc fiddle2d)
 SETUP(grid nodal_patch_map_multilevel_01.cc fiddle2d)
 SETUP(grid overlap_tria_01.cc fiddle2d)
+SETUP(grid patch_intersection_map_01.cc fiddle2d)
 SETUP(grid patch_map_01.cc fiddle2d)
 SETUP(grid patch_map_02.cc fiddle2d)
 

--- a/tests/grid/patch_intersection_map_01.cc
+++ b/tests/grid/patch_intersection_map_01.cc
@@ -1,0 +1,97 @@
+#include <fiddle/grid/patch_intersection_map.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IndexUtilities.h>
+
+#include <CartesianGridGeometry.h>
+
+// Test PatchIntersectionMap::Accessor's SAMRAI index calculations
+
+using namespace SAMRAI;
+using namespace dealii;
+
+int
+main(int argc, char **argv)
+{
+  const auto     mpi_comm = MPI_COMM_WORLD;
+  IBTK::IBTKInit ibtk_init(argc, argv, mpi_comm);
+
+  tbox::Pointer<IBTK::AppInitializer> app_initializer =
+    new IBTK::AppInitializer(argc, argv, "logfile");
+  tbox::Pointer<tbox::Database> input_db = app_initializer->getInputDatabase();
+
+  fdl::internal::PatchSingleIntersections<NDIM> intersections;
+
+  tbox::Pointer<geom::CartesianGridGeometry<NDIM>> grid_geometry =
+    new geom::CartesianGridGeometry<NDIM>("CartesianGeometry",
+                                          app_initializer->getComponentDatabase(
+                                            "CartesianGeometry"));
+
+  for (unsigned int d = 0; d < NDIM; ++d)
+    {
+      intersections.dx[d]             = grid_geometry->getDx()[d];
+      intersections.domain_x_lower[d] = grid_geometry->getXLower()[d];
+    }
+
+  intersections.lower_indices.emplace_back(hier::Index<NDIM>(0, 0));
+  intersections.lower_indices.emplace_back(hier::Index<NDIM>(0, 0));
+  intersections.lower_indices.emplace_back(hier::Index<NDIM>(1, 0));
+
+  intersections.axes.emplace_back(0);
+  intersections.axes.emplace_back(1);
+  intersections.axes.emplace_back(0);
+
+  intersections.convex_coefficients.emplace_back(0.0);
+  intersections.convex_coefficients.emplace_back(0.25);
+  intersections.convex_coefficients.emplace_back(1.0);
+
+  // Not used in the test but we need to allocate them anyway (there is an
+  // assertion that all of these arrays have the same length)
+  intersections.cell_level.push_back(0);
+  intersections.cell_level.push_back(0);
+  intersections.cell_level.push_back(0);
+
+  intersections.cell_index.push_back(0);
+  intersections.cell_index.push_back(1);
+  intersections.cell_index.push_back(0);
+
+  fdl::PatchIntersectionMap<NDIM - 1, NDIM>::Iterator it(&intersections, 0);
+
+  for (unsigned int i = 0; i < intersections.lower_indices.size(); ++i)
+    {
+      const pdat::SideIndex<NDIM> side_lower_index = it->get_side_lower();
+      const pdat::SideIndex<NDIM> side_upper_index = it->get_side_upper();
+
+      tbox::pout << "index = " << i << '\n'
+                 << "  Cell lower = " << it->get_cell_lower() << '\n'
+                 << "  Cell upper = " << it->get_cell_upper() << '\n'
+                 << "  Side lower = " << side_lower_index
+                 << " axis = " << side_lower_index.getAxis() << '\n'
+                 << "  Side upper = " << side_upper_index
+                 << " axis = " << side_upper_index.getAxis() << '\n'
+                 << "  axis = " << it->get_axis() << '\n'
+                 << "  cell convex = " << it->get_cell_convex_coefficient()
+                 << '\n'
+                 << "  side convex = " << it->get_side_convex_coefficient()
+                 << '\n'
+                 << "  point = " << it->get_point() << '\n';
+
+
+      hier::Index<NDIM>  ratio(1);
+      const IBTK::Vector side_lower =
+        IBTK::IndexUtilities::getSideCenter(grid_geometry,
+                                            ratio,
+                                            side_lower_index);
+      const IBTK::Vector side_upper =
+        IBTK::IndexUtilities::getSideCenter(grid_geometry,
+                                            ratio,
+                                            side_upper_index);
+
+      tbox::pout << "  computed side lower = " << side_lower.transpose() << '\n'
+                 << "  computed side upper = " << side_upper.transpose()
+                 << '\n';
+
+      ++it;
+    }
+}

--- a/tests/grid/patch_intersection_map_01.input
+++ b/tests/grid/patch_intersection_map_01.input
@@ -1,0 +1,19 @@
+Main {
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+
+}
+
+N = 8
+
+CartesianGeometry {
+   domain_boxes       = [(0, 0), (N - 1, N - 1)]
+   x_lo               = 1, 1
+   x_up               = 3, 3
+   periodic_dimension = 1, 1
+}

--- a/tests/grid/patch_intersection_map_01.output
+++ b/tests/grid/patch_intersection_map_01.output
@@ -1,0 +1,33 @@
+index = 0
+  Cell lower = (0,0)
+  Cell upper = (1,0)
+  Side lower = (0,0) axis = 0
+  Side upper = (1,0) axis = 0
+  axis = 0
+  cell convex = 0
+  side convex = 0.5
+  point = 1.125 1.125
+  computed side lower =     1 1.125
+  computed side upper =  1.25 1.125
+index = 1
+  Cell lower = (0,0)
+  Cell upper = (0,1)
+  Side lower = (0,0) axis = 1
+  Side upper = (0,1) axis = 1
+  axis = 1
+  cell convex = 0.25
+  side convex = 0.75
+  point = 1.125 1.1875
+  computed side lower = 1.125     1
+  computed side upper = 1.125  1.25
+index = 2
+  Cell lower = (1,0)
+  Cell upper = (2,0)
+  Side lower = (2,0) axis = 0
+  Side upper = (3,0) axis = 0
+  axis = 0
+  cell convex = 1
+  side convex = 0.5
+  point = 1.625 1.125
+  computed side lower =   1.5 1.125
+  computed side upper =  1.75 1.125


### PR DESCRIPTION
Part of #159.

After looking at #179 I came up with some ideas for how we can efficiently store and iterate over the intersections. At a high level we can build on `fdl::PatchMap`: once we know which elements intersect which patches we can compute all the intersections. For starters I am just doing one intersection per stencil.

Some next steps:
- [x] fill out the `Accessor` class. This has the advantage of putting all of the difficult to get right `SideIndex` calculations in one place.
- [x] write a corresponding `iterator` class
- [x] write some tests in which we manually populate the internal fields of `PatchSingleIntersections`

It should be possible to do most of this class without actually writing the real intersection code. That can come later (and it is logically in a level below this one).