### PR TITLE
Convert BasePatchHierarchy to PatchHierarchy.

### DIFF
--- a/include/fiddle/interaction/elemental_interaction.h
+++ b/include/fiddle/interaction/elemental_interaction.h
@@ -34,7 +34,7 @@ namespace SAMRAI
   namespace hier
   {
     template <int>
-    class BasePatchHierarchy;
+    class PatchHierarchy;
   } // namespace hier
 
   namespace tbox
@@ -70,7 +70,7 @@ namespace fdl
       const parallel::shared::Triangulation<dim, spacedim> &native_tria,
       const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
       const std::vector<float>                             &active_cell_lengths,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+      tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
       const std::pair<int, int>                            &level_numbers,
       const unsigned int                                    min_n_points_1D,
       const double                                          point_density,
@@ -85,7 +85,7 @@ namespace fdl
            const parallel::shared::Triangulation<dim, spacedim> &native_tria,
            const std::vector<BoundingBox<spacedim, float>> &active_cell_bboxes,
            const std::vector<float>                        &active_cell_lengths,
-           tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
+           tbox::Pointer<hier::PatchHierarchy<spacedim>>    patch_hierarchy,
            const std::pair<int, int> &level_numbers) override;
 
     /**

--- a/include/fiddle/interaction/interaction_base.h
+++ b/include/fiddle/interaction/interaction_base.h
@@ -17,11 +17,20 @@
 
 #include <deal.II/lac/vector.h>
 
-#include <BasePatchHierarchy.h>
+#include <tbox/Pointer.h>
 
 #include <memory>
 #include <utility>
 #include <vector>
+
+namespace SAMRAI
+{
+  namespace hier
+  {
+    template <int>
+    class PatchHierarchy;
+  }
+} // namespace SAMRAI
 
 namespace fdl
 {
@@ -257,7 +266,7 @@ namespace fdl
       const parallel::shared::Triangulation<dim, spacedim> &native_tria,
       const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
       const std::vector<float>                             &active_cell_lengths,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+      tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
       const std::pair<int, int>                            &level_numbers);
 
     /**
@@ -268,8 +277,8 @@ namespace fdl
            const parallel::shared::Triangulation<dim, spacedim> &native_tria,
            const std::vector<BoundingBox<spacedim, float>> &active_cell_bboxes,
            const std::vector<float>                        &active_cell_lengths,
-           tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
-           const std::pair<int, int>                        &level_number);
+           tbox::Pointer<hier::PatchHierarchy<spacedim>>    patch_hierarchy,
+           const std::pair<int, int>                       &level_number);
 
     /**
      * Destructor.
@@ -500,7 +509,7 @@ namespace fdl
     /**
      * Pointer to the patch hierarchy.
      */
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy;
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy;
 
     /**
      * Number of the patch level we interact with.

--- a/include/fiddle/interaction/nodal_interaction.h
+++ b/include/fiddle/interaction/nodal_interaction.h
@@ -37,7 +37,7 @@ namespace SAMRAI
   namespace hier
   {
     template <int>
-    class BasePatchHierarchy;
+    class PatchHierarchy;
   }
 
   namespace tbox
@@ -68,7 +68,7 @@ namespace fdl
       const tbox::Pointer<tbox::Database>                  &input_db,
       const parallel::shared::Triangulation<dim, spacedim> &native_tria,
       const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+      tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
       const std::pair<int, int>                            &level_numbers,
       const DoFHandler<dim, spacedim>                  &position_dof_handler,
       const LinearAlgebra::distributed::Vector<double> &position);
@@ -84,7 +84,7 @@ namespace fdl
            const parallel::shared::Triangulation<dim, spacedim> &native_tria,
            const std::vector<BoundingBox<spacedim, float>> &active_cell_bboxes,
            const std::vector<float>                        &active_cell_lengths,
-           tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
+           tbox::Pointer<hier::PatchHierarchy<spacedim>>    patch_hierarchy,
            const std::pair<int, int> &level_numbers) override;
 
     /**
@@ -93,9 +93,9 @@ namespace fdl
     virtual void
     reinit(const tbox::Pointer<tbox::Database>                  &input_db,
            const parallel::shared::Triangulation<dim, spacedim> &native_tria,
-           const std::vector<BoundingBox<spacedim, float>>  &active_cell_bboxes,
-           tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
-           const std::pair<int, int>                        &level_numbers,
+           const std::vector<BoundingBox<spacedim, float>> &active_cell_bboxes,
+           tbox::Pointer<hier::PatchHierarchy<spacedim>>    patch_hierarchy,
+           const std::pair<int, int>                       &level_numbers,
            const DoFHandler<dim, spacedim> &position_dof_handler,
            const LinearAlgebra::distributed::Vector<double> &position);
 

--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -1,5 +1,5 @@
-#ifndef included_fiddle_postprocess_meter_mesh_h
-#define included_fiddle_postprocess_meter_mesh_h
+#ifndef included_fiddle_postprocess_surface_meter_h
+#define included_fiddle_postprocess_surface_meter_h
 
 #include <fiddle/base/config.h>
 
@@ -17,9 +17,20 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <tbox/Pointer.h>
+
 #include <memory>
 #include <utility>
 #include <vector>
+
+namespace SAMRAI
+{
+  namespace hier
+  {
+    template <int>
+    class PatchHierarchy;
+  }
+} // namespace SAMRAI
 
 namespace fdl
 {
@@ -86,29 +97,26 @@ namespace fdl
      * triangulations - i.e., the exact meter Triangulation may depend on the
      * number of processors.
      */
-    SurfaceMeter(
-      const Mapping<dim, spacedim>                     &mapping,
-      const DoFHandler<dim, spacedim>                  &position_dof_handler,
-      const std::vector<Point<spacedim>>               &boundary_points,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
-      const LinearAlgebra::distributed::Vector<double> &position,
-      const LinearAlgebra::distributed::Vector<double> &velocity);
+    SurfaceMeter(const Mapping<dim, spacedim>       &mapping,
+                 const DoFHandler<dim, spacedim>    &position_dof_handler,
+                 const std::vector<Point<spacedim>> &boundary_points,
+                 tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy,
+                 const LinearAlgebra::distributed::Vector<double> &position,
+                 const LinearAlgebra::distributed::Vector<double> &velocity);
 
     /**
      * Alternate constructor which copies a pre-existing surface Triangulation.
      */
-    SurfaceMeter(
-      const Triangulation<dim - 1, spacedim>           &tria,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy);
+    SurfaceMeter(const Triangulation<dim - 1, spacedim>       &tria,
+                 tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
      * Alternate constructor which uses purely nodal data instead of finite
      * element fields.
      */
-    SurfaceMeter(
-      const std::vector<Point<spacedim>>               &boundary_points,
-      const std::vector<Tensor<1, spacedim>>           &velocity,
-      tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy);
+    SurfaceMeter(const std::vector<Point<spacedim>>           &boundary_points,
+                 const std::vector<Tensor<1, spacedim>>       &velocity,
+                 tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
      * Whether or not the SurfaceMeter was set up with a codimension zero mesh.
@@ -314,7 +322,7 @@ namespace fdl
     /**
      * Cartesian-grid data.
      */
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy;
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy;
 
     /**
      * PointValues object for computing the mesh's position.

--- a/source/interaction/elemental_interaction.cc
+++ b/source/interaction/elemental_interaction.cc
@@ -13,6 +13,7 @@ FDL_ENABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/grid/grid_tools.h>
 
 #include <CartesianPatchGeometry.h>
+#include <PatchHierarchy.h>
 
 #include <cmath>
 #include <numeric>
@@ -39,7 +40,7 @@ namespace fdl
     const parallel::shared::Triangulation<dim, spacedim> &native_tria,
     const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
     const std::vector<float>                             &active_cell_lengths,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
     const std::pair<int, int>                            &level_numbers,
     const unsigned int                                    min_n_points_1D,
     const double                                          point_density,
@@ -61,10 +62,10 @@ namespace fdl
   ElementalInteraction<dim, spacedim>::reinit(
     const tbox::Pointer<tbox::Database>                  &input_db,
     const parallel::shared::Triangulation<dim, spacedim> &native_tria,
-    const std::vector<BoundingBox<spacedim, float>>  &global_active_cell_bboxes,
-    const std::vector<float>                         &active_cell_lengths,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
-    const std::pair<int, int>                        &level_numbers)
+    const std::vector<BoundingBox<spacedim, float>> &global_active_cell_bboxes,
+    const std::vector<float>                        &active_cell_lengths,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>    patch_hierarchy,
+    const std::pair<int, int>                       &level_numbers)
   {
     InteractionBase<dim, spacedim>::reinit(input_db,
                                            native_tria,

--- a/source/interaction/interaction_base.cc
+++ b/source/interaction/interaction_base.cc
@@ -67,8 +67,8 @@ namespace fdl
     const parallel::shared::Triangulation<dim, spacedim> &n_tria,
     const std::vector<BoundingBox<spacedim, float>> &global_active_cell_bboxes,
     const std::vector<float>                        &global_active_cell_lengths,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> p_hierarchy,
-    const std::pair<int, int>                        &l_numbers)
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>    p_hierarchy,
+    const std::pair<int, int>                       &l_numbers)
     : communicator(MPI_COMM_NULL)
     , native_tria(&n_tria)
     , patch_hierarchy(p_hierarchy)
@@ -91,8 +91,8 @@ namespace fdl
     const parallel::shared::Triangulation<dim, spacedim> &n_tria,
     const std::vector<BoundingBox<spacedim, float>> &global_active_cell_bboxes,
     const std::vector<float> & /*global_active_cell_lengths*/,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> p_hierarchy,
-    const std::pair<int, int>                        &l_numbers)
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> p_hierarchy,
+    const std::pair<int, int>                    &l_numbers)
   {
     // We don't need to create a communicator unless its the first time we are
     // here or if we, for some reason, get reinitialized with a totally new

--- a/source/interaction/nodal_interaction.cc
+++ b/source/interaction/nodal_interaction.cc
@@ -13,6 +13,7 @@
 #include <deal.II/fe/mapping_fe_field.h>
 
 #include <CartesianPatchGeometry.h>
+#include <PatchHierarchy.h>
 
 #include <cmath>
 #include <numeric>
@@ -63,7 +64,7 @@ namespace fdl
     const tbox::Pointer<tbox::Database>                  &input_db,
     const parallel::shared::Triangulation<dim, spacedim> &native_tria,
     const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
     const std::pair<int, int>                            &level_numbers,
     const DoFHandler<dim, spacedim>                      &position_dof_handler,
     const LinearAlgebra::distributed::Vector<double>     &position)
@@ -84,7 +85,7 @@ namespace fdl
     const parallel::shared::Triangulation<dim, spacedim> & /*native_tria*/,
     const std::vector<BoundingBox<spacedim, float>> & /*active_cell_bboxes*/,
     const std::vector<float> & /*active_cell_lengths*/,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> /*patch_hierarchy*/,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> /*patch_hierarchy*/,
     const std::pair<int, int> & /*level_numbers*/)
   {
     AssertThrow(false,
@@ -100,7 +101,7 @@ namespace fdl
     const tbox::Pointer<tbox::Database>                  &input_db,
     const parallel::shared::Triangulation<dim, spacedim> &native_tria,
     const std::vector<BoundingBox<spacedim, float>>      &active_cell_bboxes,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>>     patch_hierarchy,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>         patch_hierarchy,
     const std::pair<int, int>                            &level_numbers,
     const DoFHandler<dim, spacedim>                      &position_dof_handler,
     const LinearAlgebra::distributed::Vector<double>     &position)

--- a/source/postprocess/surface_meter.cc
+++ b/source/postprocess/surface_meter.cc
@@ -107,8 +107,7 @@ namespace fdl
       template <int spacedim>
       double
       compute_min_cell_width(
-        const tbox::Pointer<hier::BasePatchHierarchy<spacedim>>
-          &patch_hierarchy)
+        const tbox::Pointer<hier::PatchHierarchy<spacedim>> &patch_hierarchy)
       {
         double dx = std::numeric_limits<double>::max();
         const tbox::Pointer<hier::PatchLevel<spacedim>> level =
@@ -137,7 +136,7 @@ namespace fdl
     const Mapping<dim, spacedim>                     &mapping,
     const DoFHandler<dim, spacedim>                  &position_dof_handler,
     const std::vector<Point<spacedim>>               &boundary_points,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>>     patch_hierarchy,
     const LinearAlgebra::distributed::Vector<double> &position,
     const LinearAlgebra::distributed::Vector<double> &velocity)
     : mapping(&mapping)
@@ -161,8 +160,8 @@ namespace fdl
 
   template <int dim, int spacedim>
   SurfaceMeter<dim, spacedim>::SurfaceMeter(
-    const Triangulation<dim - 1, spacedim>           &tria,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy)
+    const Triangulation<dim - 1, spacedim>       &tria,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
     : patch_hierarchy(patch_hierarchy)
     , meter_tria(tbox::SAMRAI_MPI::getCommunicator(),
                  Triangulation<dim - 1, spacedim>::MeshSmoothing::none,
@@ -186,9 +185,9 @@ namespace fdl
 
   template <int dim, int spacedim>
   SurfaceMeter<dim, spacedim>::SurfaceMeter(
-    const std::vector<Point<spacedim>>               &boundary_points,
-    const std::vector<Tensor<1, spacedim>>           &velocity,
-    tbox::Pointer<hier::BasePatchHierarchy<spacedim>> patch_hierarchy)
+    const std::vector<Point<spacedim>>           &boundary_points,
+    const std::vector<Tensor<1, spacedim>>       &velocity,
+    tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
     : patch_hierarchy(patch_hierarchy)
     , meter_tria(tbox::SAMRAI_MPI::getCommunicator(),
                  Triangulation<dim - 1, spacedim>::MeshSmoothing::none,
@@ -211,9 +210,6 @@ namespace fdl
   bool
   SurfaceMeter<dim, spacedim>::compute_vertices_inside_domain() const
   {
-    tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy =
-      this->patch_hierarchy;
-    Assert(patch_hierarchy, ExcFDLInternalError());
     tbox::Pointer<geom::CartesianGridGeometry<spacedim>> geom =
       patch_hierarchy->getGridGeometry();
     Assert(geom, ExcFDLInternalError());


### PR DESCRIPTION
We don't support BasePatchHierarchy in IBAMR (and won't for the near future - 270 degree corners are hard). Lets use the actual class to avoid some casts.