### PR TITLE
Meter base dtor

### DIFF
--- a/include/fiddle/postprocess/meter_base.h
+++ b/include/fiddle/postprocess/meter_base.h
@@ -3,11 +3,11 @@
 
 #include <fiddle/base/config.h>
 
-#include <fiddle/interaction/nodal_interaction.h>
-
 #include <deal.II/base/point.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/tensor.h>
+
+#include <deal.II/distributed/shared_tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
@@ -19,8 +19,6 @@
 #include <tbox/Pointer.h>
 
 #include <memory>
-#include <utility>
-#include <vector>
 
 namespace SAMRAI
 {
@@ -31,6 +29,11 @@ namespace SAMRAI
   }
 } // namespace SAMRAI
 
+namespace fdl
+{
+  template <int, int>
+  class NodalInteraction;
+}
 
 namespace fdl
 {
@@ -59,9 +62,9 @@ namespace fdl
      * Destructor.
      *
      * @note This is not `=default`ed since this header uses forward
-     * declarations for a lot of things. It isn't clear to me if the compiler
-     * will generate the correct destructor (what if it gets inlined?) in this
-     * case, so the definition is in the source file to be safe.
+     * declarations for a lot of things. The full types need to be available at
+     * the point at which the destructor is defined, so so the definition is in
+     * the source file.
      */
     virtual ~MeterBase();
 

--- a/include/fiddle/postprocess/meter_base.h
+++ b/include/fiddle/postprocess/meter_base.h
@@ -55,6 +55,16 @@ namespace fdl
     MeterBase(const Triangulation<dim, spacedim>           &tria,
               tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
+    /**
+     * Destructor.
+     *
+     * @note This is not `=default`ed since this header uses forward
+     * declarations for a lot of things. It isn't clear to me if the compiler
+     * will generate the correct destructor (what if it gets inlined?) in this
+     * case, so the definition is in the source file to be safe.
+     */
+    virtual ~MeterBase();
+
     /* @name object access
      * @{
      */

--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -4,7 +4,6 @@
 #include <fiddle/base/config.h>
 
 #include <fiddle/postprocess/meter_base.h>
-#include <fiddle/postprocess/point_values.h>
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/smartpointer.h>
@@ -30,6 +29,12 @@ namespace SAMRAI
     class PatchHierarchy;
   }
 } // namespace SAMRAI
+
+namespace fdl
+{
+  template <int, int, int>
+  class PointValues;
+}
 
 namespace fdl
 {
@@ -116,6 +121,11 @@ namespace fdl
     SurfaceMeter(const std::vector<Point<spacedim>>           &boundary_points,
                  const std::vector<Tensor<1, spacedim>>       &velocity,
                  tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
+
+    /**
+     * Destructor. See the note in ~MeterBase().
+     */
+    virtual ~SurfaceMeter();
 
     /**
      * Whether or not the SurfaceMeter was set up with a codimension zero mesh.

--- a/source/postprocess/meter_base.cc
+++ b/source/postprocess/meter_base.cc
@@ -98,6 +98,10 @@ namespace fdl
   }
 
   template <int dim, int spacedim>
+  MeterBase<dim, spacedim>::~MeterBase()
+  {}
+
+  template <int dim, int spacedim>
   void
   MeterBase<dim, spacedim>::reinit_dofs()
   {

--- a/source/postprocess/meter_base.cc
+++ b/source/postprocess/meter_base.cc
@@ -3,6 +3,8 @@
 #include <fiddle/grid/box_utilities.h>
 #include <fiddle/grid/surface_tria.h>
 
+#include <fiddle/interaction/nodal_interaction.h>
+
 #include <fiddle/postprocess/meter_base.h>
 
 #include <deal.II/base/mpi.h>

--- a/source/postprocess/surface_meter.cc
+++ b/source/postprocess/surface_meter.cc
@@ -1,30 +1,21 @@
 #include <fiddle/base/exceptions.h>
 
-#include <fiddle/grid/box_utilities.h>
 #include <fiddle/grid/surface_tria.h>
 
+#include <fiddle/postprocess/point_values.h>
 #include <fiddle/postprocess/surface_meter.h>
 
 #include <deal.II/base/mpi.h>
 
-#include <deal.II/dofs/dof_tools.h>
-
 #include <deal.II/fe/fe_nothing.h>
-#include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/fe_simplex_p.h>
-#include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/filtered_iterator.h>
-#include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 
-#include <deal.II/numerics/vector_tools_interpolate.h>
-#include <deal.II/numerics/vector_tools_mean_value.h>
-
-#include <ibtk/IndexUtilities.h>
-
 #include <CartesianPatchGeometry.h>
+#include <PatchHierarchy.h>
+#include <PatchLevel.h>
 
 #include <cmath>
 #include <limits>
@@ -169,6 +160,10 @@ namespace fdl
   {
     reinit(boundary_points, velocity);
   }
+
+  template <int dim, int spacedim>
+  SurfaceMeter<dim, spacedim>::~SurfaceMeter()
+  {}
 
   template <int dim, int spacedim>
   bool


### PR DESCRIPTION
We should make the dtor virtual in case we have a pointer to the base class. While we're here: clean up the headers some more.