### PR TITLE
Box predicate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ SET(FIDDLE_SRC
   source/grid/box_utilities.cc
   source/grid/data_in.cc
   source/grid/grid_utilities.cc
-  source/grid/intersection_predicate.cc
+  source/grid/intersection_predicate_lib.cc
   source/grid/nodal_patch_map.cc
   source/grid/overlap_tria.cc
   source/grid/patch_map.cc

--- a/include/fiddle/grid/intersection_predicate.h
+++ b/include/fiddle/grid/intersection_predicate.h
@@ -3,11 +3,7 @@
 
 #include <fiddle/base/config.h>
 
-#include <deal.II/base/bounding_box.h>
-
 #include <deal.II/grid/tria.h>
-
-#include <vector>
 
 namespace fdl
 {
@@ -35,50 +31,6 @@ namespace fdl
       const = 0;
 
     virtual ~IntersectionPredicate() = default;
-  };
-
-  /**
-   * Intersection predicate that determines intersections based on the locations
-   * of cells in the Triangulation and nothing else.
-   */
-  template <int dim, int spacedim = dim>
-  class TriaIntersectionPredicate : public IntersectionPredicate<dim, spacedim>
-  {
-  public:
-    TriaIntersectionPredicate(const std::vector<BoundingBox<spacedim>> &bboxes);
-
-    virtual bool
-    operator()(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
-      const override;
-
-    const std::vector<BoundingBox<spacedim>> patch_boxes;
-  };
-
-  /**
-   * Intersection predicate based on general bounding boxes for each cell.
-   *
-   * This class is intended for usage with parallel::shared::Triangulation. In
-   * particular, the bounding boxes associated with all active cells will be
-   * present on all processors. This is useful for creating an
-   * OverlapTriangulation on each processor with bounding boxes intersecting an
-   * arbitrary part of the Triangulation.
-   */
-  template <int dim, int spacedim = dim>
-  class BoxIntersectionPredicate : public IntersectionPredicate<dim, spacedim>
-  {
-  public:
-    BoxIntersectionPredicate(
-      const std::vector<BoundingBox<spacedim, float>>      &a_cell_bboxes,
-      const std::vector<BoundingBox<spacedim>>             &p_bboxes,
-      const parallel::shared::Triangulation<dim, spacedim> &tria);
-
-    virtual bool
-    operator()(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
-      const override;
-
-    const SmartPointer<const Triangulation<dim, spacedim>> tria;
-    const std::vector<BoundingBox<spacedim, float>>        active_cell_bboxes;
-    const std::vector<BoundingBox<spacedim>>               patch_bboxes;
   };
 } // namespace fdl
 

--- a/include/fiddle/grid/intersection_predicate_lib.h
+++ b/include/fiddle/grid/intersection_predicate_lib.h
@@ -9,6 +9,8 @@
 
 #include <deal.II/grid/tria.h>
 
+#include <deal.II/numerics/rtree.h>
+
 #include <vector>
 
 namespace fdl
@@ -46,7 +48,7 @@ namespace fdl
   public:
     BoxIntersectionPredicate(
       const std::vector<BoundingBox<spacedim, float>>      &a_cell_bboxes,
-      const std::vector<BoundingBox<spacedim>>             &p_bboxes,
+      const std::vector<BoundingBox<spacedim, float>>      &patch_bboxes,
       const parallel::shared::Triangulation<dim, spacedim> &tria);
 
     virtual bool
@@ -55,7 +57,8 @@ namespace fdl
 
     const SmartPointer<const Triangulation<dim, spacedim>> tria;
     const std::vector<BoundingBox<spacedim, float>>        active_cell_bboxes;
-    const std::vector<BoundingBox<spacedim>>               patch_bboxes;
+
+    RTree<BoundingBox<spacedim, float>> patch_bbox_rtree;
   };
 } // namespace fdl
 

--- a/include/fiddle/grid/intersection_predicate_lib.h
+++ b/include/fiddle/grid/intersection_predicate_lib.h
@@ -1,0 +1,62 @@
+#ifndef included_fiddle_intersection_predicate_lib_h
+#define included_fiddle_intersection_predicate_lib_h
+
+#include <fiddle/base/config.h>
+
+#include <fiddle/grid/intersection_predicate.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include <deal.II/grid/tria.h>
+
+#include <vector>
+
+namespace fdl
+{
+  using namespace dealii;
+  /**
+   * Intersection predicate that determines intersections based on the locations
+   * of cells in the Triangulation and nothing else.
+   */
+  template <int dim, int spacedim = dim>
+  class TriaIntersectionPredicate : public IntersectionPredicate<dim, spacedim>
+  {
+  public:
+    TriaIntersectionPredicate(const std::vector<BoundingBox<spacedim>> &bboxes);
+
+    virtual bool
+    operator()(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
+      const override;
+
+    const std::vector<BoundingBox<spacedim>> patch_boxes;
+  };
+
+  /**
+   * Intersection predicate based on general bounding boxes for each cell.
+   *
+   * This class is intended for usage with parallel::shared::Triangulation. In
+   * particular, the bounding boxes associated with all active cells will be
+   * present on all processors. This is useful for creating an
+   * OverlapTriangulation on each processor with bounding boxes intersecting an
+   * arbitrary part of the Triangulation.
+   */
+  template <int dim, int spacedim = dim>
+  class BoxIntersectionPredicate : public IntersectionPredicate<dim, spacedim>
+  {
+  public:
+    BoxIntersectionPredicate(
+      const std::vector<BoundingBox<spacedim, float>>      &a_cell_bboxes,
+      const std::vector<BoundingBox<spacedim>>             &p_bboxes,
+      const parallel::shared::Triangulation<dim, spacedim> &tria);
+
+    virtual bool
+    operator()(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
+      const override;
+
+    const SmartPointer<const Triangulation<dim, spacedim>> tria;
+    const std::vector<BoundingBox<spacedim, float>>        active_cell_bboxes;
+    const std::vector<BoundingBox<spacedim>>               patch_bboxes;
+  };
+} // namespace fdl
+
+#endif

--- a/source/grid/intersection_predicate_lib.cc
+++ b/source/grid/intersection_predicate_lib.cc
@@ -1,7 +1,7 @@
 #include <fiddle/base/exceptions.h>
 
 #include <fiddle/grid/box_utilities.h>
-#include <fiddle/grid/intersection_predicate.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 
 #include <deal.II/distributed/shared_tria.h>
 

--- a/source/grid/intersection_predicate_lib.cc
+++ b/source/grid/intersection_predicate_lib.cc
@@ -5,6 +5,8 @@
 
 #include <deal.II/distributed/shared_tria.h>
 
+#include <boost/iterator/function_output_iterator.hpp>
+
 namespace fdl
 {
   using namespace dealii;
@@ -30,11 +32,11 @@ namespace fdl
   template <int dim, int spacedim>
   BoxIntersectionPredicate<dim, spacedim>::BoxIntersectionPredicate(
     const std::vector<BoundingBox<spacedim, float>>      &a_cell_bboxes,
-    const std::vector<BoundingBox<spacedim>>             &p_bboxes,
+    const std::vector<BoundingBox<spacedim, float>>      &patch_bboxes,
     const parallel::shared::Triangulation<dim, spacedim> &tria)
     : tria(&tria)
     , active_cell_bboxes(a_cell_bboxes)
-    , patch_bboxes(p_bboxes)
+    , patch_bbox_rtree(pack_rtree(patch_bboxes))
   {}
 
   template <int dim, int spacedim>
@@ -45,14 +47,24 @@ namespace fdl
     Assert(&cell->get_triangulation() == tria,
            ExcMessage("only valid for inputs constructed from the originally "
                       "provided Triangulation"));
+
+    auto intersects_any_patch = [&](const auto &bbox)
+    {
+      // avoid allocating by setting to true once we have an intersection.
+      // AFAICT there is no way to instruct boost to stop at one.
+      bool result   = false;
+      namespace bgi = boost::geometry::index;
+      patch_bbox_rtree.query(bgi::intersects(bbox),
+                             boost::make_function_output_iterator(
+                               [&](const auto &) { result = true; }));
+      return result;
+    };
     // If the cell is active check its bbox:
     if (cell->is_active())
       {
-        const auto &cell_bbox = active_cell_bboxes[cell->active_cell_index()];
-        for (const auto &bbox : patch_bboxes)
-          if (intersects(cell_bbox, bbox))
-            return true;
-        return false;
+        AssertIndexRange(cell->active_cell_index(), active_cell_bboxes.size());
+        return intersects_any_patch(
+          active_cell_bboxes[cell->active_cell_index()]);
       }
     // Otherwise see if it has a descendant that intersects:
     else if (cell->has_children())
@@ -72,21 +84,19 @@ namespace fdl
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        Assert(false, ExcFDLNotImplemented());
       }
 
     Assert(false, ExcFDLInternalError());
     return false;
   }
 
-  template class TriaIntersectionPredicate<1, 1>;
   template class TriaIntersectionPredicate<1, 2>;
   template class TriaIntersectionPredicate<1, 3>;
   template class TriaIntersectionPredicate<2, 2>;
   template class TriaIntersectionPredicate<2, 3>;
   template class TriaIntersectionPredicate<3, 3>;
 
-  template class BoxIntersectionPredicate<1, 1>;
   template class BoxIntersectionPredicate<1, 2>;
   template class BoxIntersectionPredicate<1, 3>;
   template class BoxIntersectionPredicate<2, 2>;

--- a/source/interaction/interaction_base.cc
+++ b/source/interaction/interaction_base.cc
@@ -145,10 +145,9 @@ namespace fdl
                        level_patches.begin(),
                        level_patches.end());
       }
-    const std::vector<BoundingBox<spacedim>> patch_bboxes =
-      compute_patch_bboxes(patches,
-                           input_db->getDoubleWithDefault("ghost_cell_fraction",
-                                                          1.0));
+    const std::vector<BoundingBox<spacedim, float>> patch_bboxes =
+      compute_patch_bboxes<spacedim, float>(
+        patches, input_db->getDoubleWithDefault("ghost_cell_fraction", 1.0));
     BoxIntersectionPredicate<dim, spacedim> predicate(global_active_cell_bboxes,
                                                       patch_bboxes,
                                                       *native_tria);

--- a/source/interaction/interaction_base.cc
+++ b/source/interaction/interaction_base.cc
@@ -1,6 +1,7 @@
 #include <fiddle/base/samrai_utilities.h>
 
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 
 #include <fiddle/interaction/interaction_base.h>
 

--- a/tests/grid/grid_predicate_01.cc
+++ b/tests/grid/grid_predicate_01.cc
@@ -1,4 +1,4 @@
-#include <fiddle/grid/intersection_predicate.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 
 #include <fiddle/transfer/overlap_partitioning_tools.h>

--- a/tests/grid/patch_map_02.cc
+++ b/tests/grid/patch_map_02.cc
@@ -1,4 +1,5 @@
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 

--- a/tests/interaction/count_quadrature_points_01.cc
+++ b/tests/interaction/count_quadrature_points_01.cc
@@ -1,6 +1,7 @@
 #include <fiddle/base/exceptions.h>
 
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 

--- a/tests/interaction/interaction_base_01.cc
+++ b/tests/interaction/interaction_base_01.cc
@@ -162,8 +162,9 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
     // not make available. Set up our own (which should be equal) here:
     const auto patches =
       fdl::extract_patches(patch_hierarchy->getPatchLevel(level_number));
-    const std::vector<BoundingBox<spacedim>> patch_bboxes =
-      fdl::compute_patch_bboxes(patches, 1.0); // 1.0 needs to not be hard-coded
+    // TODO: it would be better to not hard-code 1.0
+    const std::vector<BoundingBox<spacedim, float>> patch_bboxes =
+      fdl::compute_patch_bboxes<spacedim, float>(patches, 1.0);
     fdl::BoxIntersectionPredicate<dim, spacedim> predicate(cell_bboxes,
                                                            patch_bboxes,
                                                            native_tria);

--- a/tests/interaction/interaction_base_01.cc
+++ b/tests/interaction/interaction_base_01.cc
@@ -1,6 +1,7 @@
 #include <fiddle/base/exceptions.h>
 
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 

--- a/tests/interaction/interpolate_01.cc
+++ b/tests/interaction/interpolate_01.cc
@@ -1,6 +1,7 @@
 #include <fiddle/base/exceptions.h>
 
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 

--- a/tests/interaction/interpolate_02.cc
+++ b/tests/interaction/interpolate_02.cc
@@ -1,4 +1,5 @@
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 

--- a/tests/interaction/spread_01.cc
+++ b/tests/interaction/spread_01.cc
@@ -1,6 +1,7 @@
 #include <fiddle/base/exceptions.h>
 
 #include <fiddle/grid/box_utilities.h>
+#include <fiddle/grid/intersection_predicate_lib.h>
 #include <fiddle/grid/overlap_tria.h>
 #include <fiddle/grid/patch_map.h>
 


### PR DESCRIPTION
These functions are called a lot more now than they used to since we have meter meshes, so they are worth optimizing. This isn't too hard either - we just have to use rtrees with the correct callback syntax to prevent dynamic memory allocation.