### PR TITLE
Bump the major version number.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15.0)
 
 # Major version of fiddle. Our convention is that X.0 is a development version
 # and X.1, X.2, etc. are release versions.
-SET(FDL_VERSION_MAJOR 2)
+SET(FDL_VERSION_MAJOR 3)
 SET(FDL_VERSION_MINOR 0)
 SET(FDL_VERSION_PATCH 0)
 


### PR DESCRIPTION
I tagged a 2.1.0 release - time for a new version number.