### PR TITLE
Rename MeterBase to just Meter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ SET(FIDDLE_SRC
   source/mechanics/part_vectors.cc
   source/mechanics/fiber_network.cc
 
-  source/postprocess/meter_base.cc
+  source/postprocess/meter.cc
   source/postprocess/point_values.cc
   source/postprocess/surface_meter.cc
   source/postprocess/volume_meter.cc

--- a/include/fiddle/postprocess/meter.h
+++ b/include/fiddle/postprocess/meter.h
@@ -1,5 +1,5 @@
-#ifndef included_fiddle_postprocess_meter_base_h
-#define included_fiddle_postprocess_meter_base_h
+#ifndef included_fiddle_postprocess_meter_h
+#define included_fiddle_postprocess_meter_h
 
 #include <fiddle/base/config.h>
 
@@ -44,19 +44,19 @@ namespace fdl
    * Base class for the meter classes (SurfaceMeter and VolumeMeter).
    */
   template <int dim, int spacedim = dim>
-  class MeterBase
+  class Meter
   {
   public:
     /**
      * Constructor.
      */
-    MeterBase(tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
+    Meter(tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
      * Constructor. Copies an existing Triangulation.
      */
-    MeterBase(const Triangulation<dim, spacedim>           &tria,
-              tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
+    Meter(const Triangulation<dim, spacedim>           &tria,
+          tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
      * Destructor.
@@ -66,7 +66,7 @@ namespace fdl
      * the point at which the destructor is defined, so so the definition is in
      * the source file.
      */
-    virtual ~MeterBase();
+    virtual ~Meter();
 
     /* @name object access
      * @{
@@ -263,35 +263,35 @@ namespace fdl
 
   template <int dim, int spacedim>
   inline const Triangulation<dim, spacedim> &
-  MeterBase<dim, spacedim>::get_triangulation() const
+  Meter<dim, spacedim>::get_triangulation() const
   {
     return meter_tria;
   }
 
   template <int dim, int spacedim>
   inline const Mapping<dim, spacedim> &
-  MeterBase<dim, spacedim>::get_mapping() const
+  Meter<dim, spacedim>::get_mapping() const
   {
     return *meter_mapping;
   }
 
   template <int dim, int spacedim>
   inline const DoFHandler<dim, spacedim> &
-  MeterBase<dim, spacedim>::get_scalar_dof_handler() const
+  Meter<dim, spacedim>::get_scalar_dof_handler() const
   {
     return scalar_dof_handler;
   }
 
   template <int dim, int spacedim>
   inline const DoFHandler<dim, spacedim> &
-  MeterBase<dim, spacedim>::get_vector_dof_handler() const
+  Meter<dim, spacedim>::get_vector_dof_handler() const
   {
     return vector_dof_handler;
   }
 
   template <int dim, int spacedim>
   Point<spacedim>
-  MeterBase<dim, spacedim>::get_centroid() const
+  Meter<dim, spacedim>::get_centroid() const
   {
     return centroid;
   }

--- a/include/fiddle/postprocess/surface_meter.h
+++ b/include/fiddle/postprocess/surface_meter.h
@@ -3,7 +3,7 @@
 
 #include <fiddle/base/config.h>
 
-#include <fiddle/postprocess/meter_base.h>
+#include <fiddle/postprocess/meter.h>
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/smartpointer.h>
@@ -75,7 +75,7 @@ namespace fdl
    * std::nexttoward().
    */
   template <int dim, int spacedim = dim>
-  class SurfaceMeter : public MeterBase<dim - 1, spacedim>
+  class SurfaceMeter : public Meter<dim - 1, spacedim>
   {
   public:
     /**
@@ -123,7 +123,7 @@ namespace fdl
                  tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy);
 
     /**
-     * Destructor. See the note in ~MeterBase().
+     * Destructor. See the note in ~Meter().
      */
     virtual ~SurfaceMeter();
 

--- a/include/fiddle/postprocess/volume_meter.h
+++ b/include/fiddle/postprocess/volume_meter.h
@@ -3,7 +3,7 @@
 
 #include <fiddle/base/config.h>
 
-#include <fiddle/postprocess/meter_base.h>
+#include <fiddle/postprocess/meter.h>
 
 #include <deal.II/base/point.h>
 
@@ -27,7 +27,7 @@ namespace fdl
    * structure. Essentially the same as SurfaceMeter but without the flux parts.
    */
   template <int spacedim>
-  class VolumeMeter : public MeterBase<spacedim, spacedim>
+  class VolumeMeter : public Meter<spacedim, spacedim>
   {
   public:
     /**

--- a/source/postprocess/meter.cc
+++ b/source/postprocess/meter.cc
@@ -6,7 +6,7 @@
 
 #include <fiddle/interaction/nodal_interaction.h>
 
-#include <fiddle/postprocess/meter_base.h>
+#include <fiddle/postprocess/meter.h>
 
 #include <deal.II/base/mpi.h>
 
@@ -36,7 +36,7 @@
 namespace fdl
 {
   template <int dim, int spacedim>
-  MeterBase<dim, spacedim>::MeterBase(
+  Meter<dim, spacedim>::Meter(
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
     : patch_hierarchy(patch_hierarchy)
     , meter_tria(tbox::SAMRAI_MPI::getCommunicator(),
@@ -45,7 +45,7 @@ namespace fdl
   {}
 
   template <int dim, int spacedim>
-  MeterBase<dim, spacedim>::MeterBase(
+  Meter<dim, spacedim>::Meter(
     const Triangulation<dim, spacedim>           &tria,
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
     : patch_hierarchy(patch_hierarchy)
@@ -68,12 +68,12 @@ namespace fdl
   }
 
   template <int dim, int spacedim>
-  MeterBase<dim, spacedim>::~MeterBase()
+  Meter<dim, spacedim>::~Meter()
   {}
 
   template <int dim, int spacedim>
   void
-  MeterBase<dim, spacedim>::reinit_dofs()
+  Meter<dim, spacedim>::reinit_dofs()
   {
     Assert(meter_tria.get_reference_cells().size() == 1,
            ExcFDLNotImplemented());
@@ -141,7 +141,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   void
-  MeterBase<dim, spacedim>::reinit_centroid()
+  Meter<dim, spacedim>::reinit_centroid()
   {
     // Since we support codim-1 meshes, the centroid (computed with the integral
     // formula) may not actually exist in the mesh. Find an equivalent point on
@@ -238,7 +238,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   void
-  MeterBase<dim, spacedim>::reinit_interaction()
+  Meter<dim, spacedim>::reinit_interaction()
   {
     // As the meter mesh is in absolute coordinates we can use a normal
     // mapping here
@@ -268,7 +268,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   void
-  MeterBase<dim, spacedim>::internal_reinit()
+  Meter<dim, spacedim>::internal_reinit()
   {
     reinit_dofs();
     reinit_centroid();
@@ -277,7 +277,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   double
-  MeterBase<dim, spacedim>::compute_centroid_value(
+  Meter<dim, spacedim>::compute_centroid_value(
     const int          data_idx,
     const std::string &kernel_name) const
   {
@@ -322,9 +322,8 @@ namespace fdl
 
   template <int dim, int spacedim>
   double
-  MeterBase<dim, spacedim>::compute_mean_value(
-    const int          data_idx,
-    const std::string &kernel_name) const
+  Meter<dim, spacedim>::compute_mean_value(const int          data_idx,
+                                           const std::string &kernel_name) const
   {
     const auto interpolated_data =
       interpolate_scalar_field(data_idx, kernel_name);
@@ -338,7 +337,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   LinearAlgebra::distributed::Vector<double>
-  MeterBase<dim, spacedim>::interpolate_scalar_field(
+  Meter<dim, spacedim>::interpolate_scalar_field(
     const int          data_idx,
     const std::string &kernel_name) const
   {
@@ -358,7 +357,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   LinearAlgebra::distributed::Vector<double>
-  MeterBase<dim, spacedim>::interpolate_vector_field(
+  Meter<dim, spacedim>::interpolate_vector_field(
     const int          data_idx,
     const std::string &kernel_name) const
   {
@@ -378,7 +377,7 @@ namespace fdl
 
   template <int dim, int spacedim>
   bool
-  MeterBase<dim, spacedim>::compute_vertices_inside_domain() const
+  Meter<dim, spacedim>::compute_vertices_inside_domain() const
   {
     tbox::Pointer<geom::CartesianGridGeometry<spacedim>> geom =
       patch_hierarchy->getGridGeometry();
@@ -402,6 +401,6 @@ namespace fdl
     return vertices_inside_domain;
   }
 
-  template class MeterBase<NDIM - 1, NDIM>;
-  template class MeterBase<NDIM, NDIM>;
+  template class Meter<NDIM - 1, NDIM>;
+  template class Meter<NDIM, NDIM>;
 } // namespace fdl

--- a/source/postprocess/surface_meter.cc
+++ b/source/postprocess/surface_meter.cc
@@ -103,7 +103,7 @@ namespace fdl
     tbox::Pointer<hier::PatchHierarchy<spacedim>>     patch_hierarchy,
     const LinearAlgebra::distributed::Vector<double> &position,
     const LinearAlgebra::distributed::Vector<double> &velocity)
-    : MeterBase<dim - 1, spacedim>(patch_hierarchy)
+    : Meter<dim - 1, spacedim>(patch_hierarchy)
     , mapping(&mapping)
     , position_dof_handler(&position_dof_handler)
     , point_values(std::make_unique<PointValues<spacedim, dim, spacedim>>(
@@ -120,7 +120,7 @@ namespace fdl
   SurfaceMeter<dim, spacedim>::SurfaceMeter(
     const Triangulation<dim - 1, spacedim>       &tria,
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
-    : MeterBase<dim - 1, spacedim>(tria, patch_hierarchy)
+    : Meter<dim - 1, spacedim>(tria, patch_hierarchy)
   {
     internal_reinit(false, {}, {}, false);
   }
@@ -130,7 +130,7 @@ namespace fdl
     const std::vector<Point<spacedim>>           &boundary_points,
     const std::vector<Tensor<1, spacedim>>       &velocity,
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
-    : MeterBase<dim - 1, spacedim>(patch_hierarchy)
+    : Meter<dim - 1, spacedim>(patch_hierarchy)
   {
     reinit(boundary_points, velocity);
   }
@@ -222,7 +222,7 @@ namespace fdl
   {
     if (reinit_tria)
       this->reinit_tria(boundary_points, place_additional_boundary_vertices);
-    MeterBase<dim - 1, spacedim>::internal_reinit();
+    Meter<dim - 1, spacedim>::internal_reinit();
     reinit_mean_velocity(velocity_values);
   }
 

--- a/source/postprocess/volume_meter.cc
+++ b/source/postprocess/volume_meter.cc
@@ -14,7 +14,7 @@ namespace fdl
     const Point<spacedim>                        &center,
     const double                                 &radius,
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
-    : MeterBase<spacedim, spacedim>(patch_hierarchy)
+    : Meter<spacedim, spacedim>(patch_hierarchy)
     , center(center)
   {
     GridGenerator::hyper_ball_balanced(this->meter_tria, center, radius);
@@ -22,7 +22,7 @@ namespace fdl
 
     while (GridTools::maximal_cell_diameter(this->meter_tria) > dx)
       this->meter_tria.refine_global(1);
-    MeterBase<spacedim, spacedim>::internal_reinit();
+    Meter<spacedim, spacedim>::internal_reinit();
   }
 
   template <int spacedim>
@@ -33,7 +33,7 @@ namespace fdl
     GridTools::shift(displacement, this->meter_tria);
     center = new_center;
 
-    MeterBase<spacedim, spacedim>::internal_reinit();
+    Meter<spacedim, spacedim>::internal_reinit();
   }
 
   template <int spacedim>


### PR DESCRIPTION
The Base is redundant.

I'm going to try to clean up some class names and exception names in the near future to be clearer and not repeat information in the type system. This is based on re-reading [Exceptional Naming](https://kevlinhenney.medium.com/exceptional-naming-6e3c8f5bffac?source=author_recirc).