### PR TITLE
Development version fixes

### DIFF
--- a/source/grid/surface_tria.cc
+++ b/source/grid/surface_tria.cc
@@ -172,8 +172,8 @@ namespace fdl
     // check, element (q)uality (min angle in degrees)
     std::string flags("pzQCq");
     Assert(additional_data.min_angle > 0.0,
-           ExcMessage("The minimum angle must be larger than zero.")) flags +=
-      std::to_string(additional_data.min_angle);
+           ExcMessage("The minimum angle must be larger than zero."));
+    flags += std::to_string(additional_data.min_angle);
     if (additional_data.target_element_area ==
         std::numeric_limits<double>::max())
       {

--- a/tests/interaction/line_edge_intersection.cc
+++ b/tests/interaction/line_edge_intersection.cc
@@ -41,9 +41,9 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
   std::ofstream output("output");
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
-      std::array<Point<2>, 2> Pts = {
-        mapping.transform_unit_to_real_cell(cell, Point<1>(0)),
-        mapping.transform_unit_to_real_cell(cell, Point<1>(1))};
+      const std::array<Point<2>, 2> Pts{
+        {mapping.transform_unit_to_real_cell(cell, Point<1>(0)),
+         mapping.transform_unit_to_real_cell(cell, Point<1>(1))}};
       std_cxx17::optional<double> convex_coef =
         fdl::intersect_stencil_with_simplex<1>(
           Pts,

--- a/tests/interaction/line_face_intersection.cc
+++ b/tests/interaction/line_face_intersection.cc
@@ -40,10 +40,10 @@ test(SAMRAI::tbox::Pointer<IBTK::AppInitializer> app_initializer)
   std::ofstream output("output");
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
-      std::array<Point<3>, 3> Pts = {
-        mapping.transform_unit_to_real_cell(cell, Point<2>(0, 0)),
-        mapping.transform_unit_to_real_cell(cell, Point<2>(0, 1)),
-        mapping.transform_unit_to_real_cell(cell, Point<2>(1, 0))};
+      const std::array<Point<3>, 3> Pts{
+        {mapping.transform_unit_to_real_cell(cell, Point<2>(0, 0)),
+         mapping.transform_unit_to_real_cell(cell, Point<2>(0, 1)),
+         mapping.transform_unit_to_real_cell(cell, Point<2>(1, 0))}};
       std_cxx17::optional<double> convex_coef =
         fdl::intersect_stencil_with_simplex<2>(
           Pts,


### PR DESCRIPTION
deal.II got picker about semicolons and assertions recently. Similarly, GCC-13 requires double-braces for std::array now.