### PR TITLE
Fix a performance bug in PointValues.

### DIFF
--- a/include/fiddle/postprocess/point_values.h
+++ b/include/fiddle/postprocess/point_values.h
@@ -77,7 +77,7 @@ namespace fdl
     /**
      * Internal data structure that manages both evaluation and communication.
      */
-    mutable Utilities::MPI::RemotePointEvaluation<dim, spacedim>
+    Utilities::MPI::RemotePointEvaluation<dim, spacedim>
       remote_point_evaluation;
   };
 

--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -44,6 +44,9 @@ namespace fdl
   {
     FDL_SETUP_TIMER_AND_SCOPE(t_pointvalues_ctor,
                               "fdl::PointValues::PointValues()");
+    remote_point_evaluation.reinit(this->evaluation_points,
+                                   this->dof_handler->get_triangulation(),
+                                   *this->mapping);
   }
 
   template <int n_components, int dim, int spacedim>
@@ -54,11 +57,9 @@ namespace fdl
     FDL_SETUP_TIMER_AND_SCOPE(t_pointvalues_evaluate,
                               "fdl::PointValues::evaluate()");
     auto result =
-      VectorTools::point_values<n_components>(*mapping,
+      VectorTools::point_values<n_components>(remote_point_evaluation,
                                               *dof_handler,
-                                              vector,
-                                              evaluation_points,
-                                              remote_point_evaluation);
+                                              vector);
 
     return convert(result);
   }


### PR DESCRIPTION
Fixes https://github.com/IBAMR/fch-deal/issues/135.

The call to VectorTools::point_values() with a mapping argument reinitializes the remote point evaluation object which is very expensive (something like 1/3rd the runtime of the heart model).