### PR TITLE
Remove VolumeMeter::center.

### DIFF
--- a/include/fiddle/postprocess/volume_meter.h
+++ b/include/fiddle/postprocess/volume_meter.h
@@ -50,9 +50,6 @@ namespace fdl
      */
     void
     reinit();
-
-  protected:
-    Point<spacedim> center;
   };
 } // namespace fdl
 

--- a/source/postprocess/volume_meter.cc
+++ b/source/postprocess/volume_meter.cc
@@ -15,7 +15,6 @@ namespace fdl
     const double                                 &radius,
     tbox::Pointer<hier::PatchHierarchy<spacedim>> patch_hierarchy)
     : Meter<spacedim, spacedim>(patch_hierarchy)
-    , center(center)
   {
     FDL_SETUP_TIMER_AND_SCOPE(t_volume_meter_ctor,
                               "fdl::VolumeMeter::VolumeMeter()");
@@ -33,10 +32,7 @@ namespace fdl
   {
     FDL_SETUP_TIMER_AND_SCOPE(t_volume_meter_reinit,
                               "fdl::VolumeMeter::reinit()");
-    const Tensor<1, spacedim> displacement = new_center - center;
-    GridTools::shift(displacement, this->meter_tria);
-    center = new_center;
-
+    GridTools::shift(new_center - this->get_centroid(), this->meter_tria);
     Meter<spacedim, spacedim>::internal_reinit();
   }
 


### PR DESCRIPTION
We never use it - the centroid is always available through the base class.