### PR TITLE
Prevent in-source builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.15.0)
 
+# Do this before project() to skip the compiler config process
+IF("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+  MESSAGE(FATAL_ERROR "This project does not support in-source builds.
+    Please create a subfolder and use `cmake ..` inside it.
+    NOTE: cmake will now create CMakeCache.txt and CMakeFiles/*.
+          You must delete them, or cmake will refuse to work.")
+ENDIF()
+
 # Major version of fiddle. Our convention is that X.0 is a development version
 # and X.1, X.2, etc. are release versions.
 SET(FDL_VERSION_MAJOR 3)


### PR DESCRIPTION
This doesn't work with the test suite and in-source builds are just a bad idea anyway.